### PR TITLE
error if startTransaction returns a ConcurrentTx status

### DIFF
--- a/src/lib/ChargeStation/index.js
+++ b/src/lib/ChargeStation/index.js
@@ -276,6 +276,13 @@ class Session {
         `OCPP Server rejected our Token UID during StartTransaction: ${this.options.uid}`
       );
     }
+
+    if (startTransactionResponse.idTagInfo.status === 'ConcurrentTx') {
+      throw new Error(
+        `OCPP Server did not start transaction due to ConcurrentTx: ${this.options.uid}`
+      );
+    }
+
     this.transactionId = startTransactionResponse.transactionId;
 
     await this.options.sendCommand('StatusNotification', {


### PR DESCRIPTION
If an OCPP server attempts to start a transaction with a valid `idTag`, but the server subsequently rejects the request due to a `ConcurrentTx` status code, surface this as an error to the user. 