### PR TITLE
Specify websocket subprotocol

### DIFF
--- a/src/lib/protocols/ocpp-1.6/index.js
+++ b/src/lib/protocols/ocpp-1.6/index.js
@@ -10,7 +10,7 @@ class Connection {
 
   connect() {
     const url = this.ocppBaseUrl + '/' + this.ocppIdentity;
-    this.ws = new WebSocket(url);
+    this.ws = new WebSocket(url, 'ocpp1.6');
     this.ws.addEventListener('open', () => {
       this.ready = true;
       this.onConnected && this.onConnected();


### PR DESCRIPTION
As per section 3.1.2 of Open Charge Point Protocol JSON 1.6, OCPP-J 1.6 Specification (this is equally covered in the 2.0.1 spec too).

<img width="911" alt="Screenshot 2023-07-11 at 15 45 00" src="https://github.com/e-flux-platform/chargestation/assets/350792/36072b8a-12e9-47df-b227-189eca864e20">
