### PR TITLE
Ensure chargePointVendor is sent during boot notification

### DIFF
--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -6,9 +6,9 @@ export const settingsList = [
     defaultValue: 'ws://localhost:2600/1.6/e-flux',
   },
   {
-    key: 'chargepointVendor',
+    key: 'chargePointVendor',
     name: 'Boot / Vendor',
-    description: 'The chargepointVendor sent during BootNotification',
+    description: 'The chargePointVendor sent during BootNotification',
     defaultValue: 'Chargepoint.one',
   },
   {


### PR DESCRIPTION
This should be `chargePoint` instead of `chargepoint` - https://github.com/e-flux-platform/chargestation/blob/bfa771608e622001b1ce2739bc8bf7a6b69c2547/src/lib/ChargeStation/index.js#L164