### PR TITLE
Refactor configuration to support SetVariables

### DIFF
--- a/src/lib/ChargeStation/configurations/default-ocpp-201.js
+++ b/src/lib/ChargeStation/configurations/default-ocpp-201.js
@@ -8,6 +8,7 @@ import sendHeartbeatDelayed from '../eventHandlers/ocpp-201/send-heartbeat-delay
 import handleBootNotificationCallResultReceived from '../eventHandlers/ocpp-201/handle-boot-notification-call-result-received';
 import handleHeartbeatCallResultReceived from '../eventHandlers/ocpp-201/handle-heartbeat-call-result-received';
 import handleGetBaseReportReceived from '../eventHandlers/ocpp-201/handle-get-base-report-received';
+import handleSetVariables from '../eventHandlers/ocpp-201/handle-set-variables';
 
 // This is the default configuration for OCPP 2.0.1
 // Each key represents an event, and the value represents an array of handlers that will be called when the event is emitted
@@ -20,4 +21,5 @@ export default {
   [e.HeartbeatCallResultReceived]: [handleHeartbeatCallResultReceived],
   [e.HeartbeatAccepted]: [sendHeartbeatDelayed],
   [e201.GetBaseReportReceived]: [handleGetBaseReportReceived],
+  [e201.SetVariablesReceived]: [handleSetVariables],
 };

--- a/src/lib/ChargeStation/eventHandlers/event-types.js
+++ b/src/lib/ChargeStation/eventHandlers/event-types.js
@@ -33,4 +33,5 @@ export const EventTypes16 = {
 // Specific to OCPP 2.0.1
 export const EventTypes201 = {
   GetBaseReportReceived: 'getBaseReportReceived',
+  SetVariablesReceived: 'setVariablesReceived',
 };

--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-change-configuration.js
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-change-configuration.js
@@ -3,8 +3,13 @@ export default async function handleChangeConfiguration({
   callMessageId,
   callMessageBody,
 }) {
-  const { key, value } = callMessageBody;
-  chargepoint.configuration[key] = value;
+  chargepoint.configuration.setVariable(key, callMessageBody);
+
+  if (chargepoint.configuration[key]) {
+    chargepoint.configuration[key].value = value;
+  } else {
+    chargepoint.configuration[key] = callMessageBody;
+  }
 
   const response = {
     status: 'Accepted',

--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-change-configuration.js
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-change-configuration.js
@@ -7,12 +7,6 @@ export default async function handleChangeConfiguration({
 
   chargepoint.configuration.setVariable(key, callMessageBody);
 
-  if (chargepoint.configuration[key]) {
-    chargepoint.configuration[key].value = value;
-  } else {
-    chargepoint.configuration[key] = callMessageBody;
-  }
-
   const response = {
     status: 'Accepted',
   };

--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-change-configuration.js
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-change-configuration.js
@@ -3,6 +3,8 @@ export default async function handleChangeConfiguration({
   callMessageId,
   callMessageBody,
 }) {
+  const { key } = callMessageBody;
+
   chargepoint.configuration.setVariable(key, callMessageBody);
 
   if (chargepoint.configuration[key]) {

--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-get-configuration.js
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-get-configuration.js
@@ -5,7 +5,6 @@ export default async function handleGetConfiguration({
   const response = {
     configurationKey: chargepoint.configuration
       .getVariablesArray()
-      // TODO: Move mapping to configuration class
       .map((variable) => {
         return {
           key: variable.key,

--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-get-configuration.js
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-get-configuration.js
@@ -3,13 +3,16 @@ export default async function handleGetConfiguration({
   callMessageId,
 }) {
   const response = {
-    configurationKey: Object.keys(chargepoint.configuration).map((key) => {
-      return {
-        key,
-        value: chargepoint.configuration[key],
-        readOnly: false,
-      };
-    }),
+    configurationKey: chargepoint.configuration
+      .getVariablesArray()
+      // TODO: Move mapping to configuration class
+      .map((variable) => {
+        return {
+          key: variable.key,
+          value: variable.value,
+          readOnly: false,
+        };
+      }),
     unknownKey: [],
   };
   chargepoint.writeCallResult(callMessageId, response);

--- a/src/lib/ChargeStation/eventHandlers/ocpp-201/handle-get-base-report-received.js
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-201/handle-get-base-report-received.js
@@ -1,4 +1,3 @@
-import { configurationList201 } from 'lib/settings';
 import { sleep } from 'utils/csv';
 
 export default async function handleGetBaseReportReceived({
@@ -13,10 +12,10 @@ export default async function handleGetBaseReportReceived({
 
   const { requestId } = callMessageBody;
 
-  const list = [...configurationList201];
-  const middleIndex = Math.ceil(list.length / 2);
-  const firstHalf = list.splice(0, middleIndex);
-  const secondHalf = list.splice(-middleIndex);
+  const variables = chargepoint.configuration.getVariablesArray();
+  const middleIndex = Math.ceil(variables.length / 2);
+  const firstHalf = variables.splice(0, middleIndex);
+  const secondHalf = variables.splice(-middleIndex);
 
   await chargepoint.writeCall('NotifyReport', {
     requestId,

--- a/src/lib/ChargeStation/eventHandlers/ocpp-201/handle-set-variables.js
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-201/handle-set-variables.js
@@ -1,0 +1,20 @@
+import { getConfigurationKey201 } from '../../../settings';
+
+export default async function handleSetVariables({
+  chargepoint,
+  callMessageId,
+  callMessageBody,
+}) {
+  const { setVariableData } = callMessageBody;
+
+  for (const variable of setVariableData) {
+    const key = getConfigurationKey201(variable);
+    chargepoint.configuration.setVariable(key, variable);
+  }
+
+  const response = {
+    status: 'Accepted',
+  };
+
+  chargepoint.writeCallResult(callMessageId, response);
+}

--- a/src/lib/ChargeStation/index.js
+++ b/src/lib/ChargeStation/index.js
@@ -42,23 +42,11 @@ export default class ChargeStation {
     }
   }
 
-  getOCPPIdentity() {
-    switch (this.options?.ocppConfiguration) {
-      case 'ocpp1.6':
-        return this.configuration['Identity'];
-      case 'ocpp2.0.1':
-        return this.configuration['SecurityCtrlr.Identity'];
-      default:
-        return this.configuration['Identity'];
-    }
-  }
-
   connect() {
     this.setup();
     const ocppBaseUrl =
-      extractOcppBaseUrlFromConfiguration(this.configuration) ||
-      this.options.ocppBaseUrl;
-    const ocppIdentity = this.getOCPPIdentity();
+      this.configuration.getBaseURL() || this.options.ocppBaseUrl;
+    const ocppIdentity = this.configuration.getOCPPIdentityString();
     this.log('message', `> Connecting to ${ocppBaseUrl}/${ocppIdentity}`);
 
     this.connection = this.getConnection(ocppBaseUrl, ocppIdentity);
@@ -145,10 +133,7 @@ export default class ChargeStation {
         ...session,
         writeCall: this.writeCall.bind(this),
         writeCallResult: this.writeCallResult.bind(this),
-        meterValuesInterval: parseInt(
-          this.configuration['MeterValueSampleInterval'] || '60',
-          10
-        ),
+        meterValuesInterval: this.configuration.getMeterValueSampleInterval(),
         getCurrentStatus: () => this.currentStatus[connectorId],
       },
       this.emitter

--- a/src/lib/ChargeStation/index.js
+++ b/src/lib/ChargeStation/index.js
@@ -1,4 +1,4 @@
-import { extractOcppBaseUrlFromConfiguration, toCamelCase } from './utils';
+import { toCamelCase } from './utils';
 import { Connection } from './connection';
 import { sleep } from 'utils/csv';
 import { createEventEmitter } from './eventHandlers';
@@ -48,8 +48,7 @@ export default class ChargeStation {
 
   connect() {
     this.setup();
-    const ocppBaseUrl =
-      this.configuration.getBaseURL() || this.options.ocppBaseUrl;
+    const ocppBaseUrl = this.options.ocppBaseUrl || this.options.ocppBaseUrl;
     const ocppIdentity = this.configuration.getOCPPIdentityString();
     this.log('message', `> Connecting to ${ocppBaseUrl}/${ocppIdentity}`);
 

--- a/src/lib/ChargeStation/index.js
+++ b/src/lib/ChargeStation/index.js
@@ -18,6 +18,10 @@ export default class ChargeStation {
     };
   }
 
+  changeConfiguration(configuration) {
+    this.configuration = configuration;
+  }
+
   availableConnectors() {
     return ['1', '2'].filter((id) => !this.sessions[id]);
   }

--- a/src/lib/ChargeStation/utils.js
+++ b/src/lib/ChargeStation/utils.js
@@ -1,26 +1,3 @@
-export function extractOcppBaseUrlFromConfiguration(configuration) {
-  // Alfen
-  if (
-    configuration['BackOffice-URL-wired'] &&
-    configuration['BackOffice-Path-wired']
-  ) {
-    return `${configuration['BackOffice-URL-wired']}${configuration['BackOffice-Path-wired']}`;
-  }
-  if (
-    configuration['BackOffice-URL-APN'] &&
-    configuration['BackOffice-Path-APN']
-  ) {
-    return `${configuration['BackOffice-URL-APN']}${configuration['BackOffice-Path-APN']}`;
-  }
-
-  // Evnex
-  if (configuration['OCPPEndPoint']) {
-    return configuration['OCPPEndPoint'];
-  }
-
-  return null;
-}
-
 export function summarizeCommandParams({ method, params }) {
   if (method === 'StartTransaction') {
     return { meterStart: params.meterStart, uid: params.idTag };

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -547,7 +547,7 @@ class VariableConfiguration201 {
 
     const intervalConfig = this.variables['MeterValueSampleInterval'];
 
-    const actualValue = intervalConfig.variableAttribute.find(
+    const actualValue = intervalConfig?.variableAttribute?.find(
       (attr) => attr.type === 'Actual' || !attr.type
     );
 
@@ -557,7 +557,7 @@ class VariableConfiguration201 {
     return parseInt(actualValue.value);
   }
 
-  variablesToSimpleSettingsMap() {
+  variablesToSimpleConfigurationMap() {
     return Object.keys(this.variables).reduce((acc, key) => {
       acc[key] = {
         key,
@@ -567,7 +567,7 @@ class VariableConfiguration201 {
     }, {});
   }
 
-  updateVariablesFromSimpleSettingsMap(variables) {
+  updateVariablesFromSimpleConfigurationMap(variables) {
     for (const variable of Object.values(variables)) {
       if (!this.variables[variable.key]) {
         throw new Error(`Variable ${variable.key} not found in configuration`);
@@ -659,11 +659,11 @@ class VariableConfiguration16 {
     return parseInt(intervalConfig);
   }
 
-  variablesToSimpleSettingsMap() {
+  variablesToSimpleConfigurationMap() {
     return this.variables;
   }
 
-  updateVariablesFromSimpleSettingsMap(variables) {
+  updateVariablesFromSimpleConfigurationMap(variables) {
     for (const variable of Object.values(variables)) {
       if (!this.variables[variable.key]) {
         throw new Error(`Variable ${variable.key} not found in configuration`);

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -544,17 +544,8 @@ class VariableConfiguration201 {
 
   getMeterValueSampleInterval() {
     const defaultInterval = 60;
-
-    const intervalConfig = this.variables['MeterValueSampleInterval'];
-
-    const actualValue = intervalConfig?.variableAttribute?.find(
-      (attr) => attr.type === 'Actual' || !attr.type
-    );
-
-    if (!actualValue) return defaultInterval;
-
-    // Not sure if parseInt is necessary here
-    return parseInt(actualValue.value);
+    const value = this.getVariableActualValue('MeterValueSampleInterval');
+    return value || defaultInterval;
   }
 
   variablesToSimpleConfigurationMap() {

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -314,7 +314,7 @@ export const defaultVariableConfig201 = [
     },
     variableAttribute: [
       {
-        value: '                                     ',
+        value: '',
         persistent: true,
         constant: false,
       },
@@ -528,25 +528,6 @@ export function getDefaultSession() {
   }
   return result;
 }
-//
-// function buildConfigurationMap201() {
-//   const query = getDocumentQuery();
-//   const list = configurationList201;
-//   const result = {};
-//
-//   for (const item of list) {
-//     const key = getConfigurationKey201(item);
-//     const value = getConfigurationValue201(item);
-//
-//     if (query.get(key)) {
-//       result[key] = query.get(key);
-//       continue;
-//     }
-//     result[key] = value;
-//   }
-//
-//   return result;
-// }
 
 class Configuration201 {
   constructor(variables) {
@@ -773,36 +754,3 @@ export const getConfigurationKey201 = (item) => {
 
   return key;
 };
-
-const getConfigurationValue201 = (item) => {
-  return item.variableAttribute[0].value;
-};
-
-// function buildConfigurationMap16() {
-//   const list = configurationList16;
-//   const query = getDocumentQuery();
-//   const result = {};
-//
-//   for (const item of list) {
-//     const { key } = item;
-//     if (query.get(key)) {
-//       result[key] = query.get(key);
-//       continue;
-//     }
-//     result[key] = item.defaultValue;
-//   }
-//
-//   return result;
-// }
-//
-// export function getConfigurationList(ocppVersion) {
-//   if (ocppVersion === 'ocpp2.0.1') {
-//     return configurationList201.map((item) => {
-//       const key = getConfigurationKey201(item);
-//       const value = getConfigurationValue201(item);
-//
-//       return { key, defaultValue: value };
-//     });
-//   }
-//   return configurationList16;
-// }

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -503,9 +503,9 @@ export function getSettings() {
 export function getConfiguration(ocppVersion) {
   switch (ocppVersion) {
     case 'ocpp1.6':
-      return new Configuration201(defaultVariableConfig16);
+      return new VariableConfiguration16(defaultVariableConfig16);
     case 'ocpp2.0.1':
-      return new Configuration201(defaultVariableConfig201);
+      return new VariableConfiguration201(defaultVariableConfig201);
     default:
       throw new Error(`Unsupported OCPP version: ${ocppVersion}`);
   }
@@ -529,7 +529,7 @@ export function getDefaultSession() {
   return result;
 }
 
-class Configuration201 {
+class VariableConfiguration201 {
   constructor(variables) {
     this.variables = variables.reduce((acc, item) => {
       const key = getConfigurationKey201(item);

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -529,8 +529,33 @@ export function getDefaultSession() {
   return result;
 }
 
-class VariableConfiguration201 {
+class VariableConfiguration {
+  getOCPPIdentityString() {
+    throw new Error('Not implemented');
+  }
+  getMeterValueSampleInterval() {
+    throw new Error('Not implemented');
+  }
+  variablesToKeyValueMap() {
+    throw new Error('Not implemented');
+  }
+  updateVariablesFromKeyValueMap(variables) {
+    throw new Error('Not implemented');
+  }
+  setVariable(key, variable) {
+    throw new Error('Not implemented');
+  }
+  getVariableActualValue(key) {
+    throw new Error('Not implemented');
+  }
+  getVariablesArray() {
+    throw new Error('Not implemented');
+  }
+}
+
+class VariableConfiguration201 extends VariableConfiguration {
   constructor(variables) {
+    super();
     this.variables = variables.reduce((acc, item) => {
       const key = getConfigurationKey201(item);
       acc[key] = item;
@@ -548,7 +573,7 @@ class VariableConfiguration201 {
     return value || defaultInterval;
   }
 
-  variablesToSimpleConfigurationMap() {
+  variablesToKeyValueMap() {
     return Object.keys(this.variables).reduce((acc, key) => {
       acc[key] = {
         key,
@@ -558,7 +583,7 @@ class VariableConfiguration201 {
     }, {});
   }
 
-  updateVariablesFromSimpleConfigurationMap(variables) {
+  updateVariablesFromKeyValueMap(variables) {
     for (const variable of Object.values(variables)) {
       if (!this.variables[variable.key]) {
         throw new Error(`Variable ${variable.key} not found in configuration`);
@@ -629,8 +654,9 @@ class VariableConfiguration201 {
   }
 }
 
-class VariableConfiguration16 {
+class VariableConfiguration16 extends VariableConfiguration {
   constructor(variables) {
+    super();
     this.variables = variables.reduce((acc, item) => {
       acc[item.key] = item;
       return acc;
@@ -650,11 +676,11 @@ class VariableConfiguration16 {
     return parseInt(intervalConfig);
   }
 
-  variablesToSimpleConfigurationMap() {
+  variablesToKeyValueMap() {
     return this.variables;
   }
 
-  updateVariablesFromSimpleConfigurationMap(variables) {
+  updateVariablesFromKeyValueMap(variables) {
     for (const variable of Object.values(variables)) {
       if (!this.variables[variable.key]) {
         throw new Error(`Variable ${variable.key} not found in configuration`);

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -557,29 +557,6 @@ class VariableConfiguration201 {
     return parseInt(actualValue.value);
   }
 
-  getBaseURL() {
-    // Alfen
-    if (
-      this.variables['BackOffice-URL-wired'] &&
-      this.variables['BackOffice-Path-wired']
-    ) {
-      return `${this.variables['BackOffice-URL-wired']}${this.variables['BackOffice-Path-wired']}`;
-    }
-    if (
-      this.variables['BackOffice-URL-APN'] &&
-      this.variables['BackOffice-Path-APN']
-    ) {
-      return `${this.variables['BackOffice-URL-APN']}${this.variables['BackOffice-Path-APN']}`;
-    }
-
-    // Evnex
-    if (this.variables['OCPPEndPoint']) {
-      return this.variables['OCPPEndPoint'];
-    }
-
-    return null;
-  }
-
   variablesToSimpleSettingsMap() {
     return Object.keys(this.variables).reduce((acc, key) => {
       acc[key] = {
@@ -680,29 +657,6 @@ class VariableConfiguration16 {
     if (!intervalConfig) return defaultInterval;
 
     return parseInt(intervalConfig);
-  }
-
-  getBaseURL() {
-    // Alfen
-    if (
-      this.variables['BackOffice-URL-wired'] &&
-      this.variables['BackOffice-Path-wired']
-    ) {
-      return `${this.variables['BackOffice-URL-wired']}${this.variables['BackOffice-Path-wired']}`;
-    }
-    if (
-      this.variables['BackOffice-URL-APN'] &&
-      this.variables['BackOffice-Path-APN']
-    ) {
-      return `${this.variables['BackOffice-URL-APN']}${this.variables['BackOffice-Path-APN']}`;
-    }
-
-    // Evnex
-    if (this.variables['OCPPEndPoint']) {
-      return this.variables['OCPPEndPoint'];
-    }
-
-    return null;
   }
 
   variablesToSimpleSettingsMap() {

--- a/src/screens/Dashboard/SettingsModal.js
+++ b/src/screens/Dashboard/SettingsModal.js
@@ -6,7 +6,7 @@ import { HelpTip } from 'components';
 @modal
 export default class SettingsModal extends React.Component {
   state = {
-    config: this.props.configuration.variablesToSimpleConfigurationMap(),
+    config: this.props.configuration.variablesToKeyValueMap(),
     settings: this.props.settings || [],
     settingsList: this.props.settingsList || [],
   };

--- a/src/screens/Dashboard/SettingsModal.js
+++ b/src/screens/Dashboard/SettingsModal.js
@@ -6,7 +6,7 @@ import { HelpTip } from 'components';
 @modal
 export default class SettingsModal extends React.Component {
   state = {
-    config: this.props.configuration.variablesToSimpleSettingsMap(),
+    config: this.props.configuration.variablesToSimpleConfigurationMap(),
     settings: this.props.settings || [],
     settingsList: this.props.settingsList || [],
   };

--- a/src/screens/Dashboard/SettingsModal.js
+++ b/src/screens/Dashboard/SettingsModal.js
@@ -6,10 +6,9 @@ import { HelpTip } from 'components';
 @modal
 export default class SettingsModal extends React.Component {
   state = {
-    settings: this.props.settings || {},
-    configuration: this.props.configuration || {},
+    config: this.props.configuration.variablesToSimpleSettingsMap(),
+    settings: this.props.settings || [],
     settingsList: this.props.settingsList || [],
-    configurationList: this.props.configurationList || [],
   };
 
   setSettingsField = (e, { name, value }) => {
@@ -24,9 +23,12 @@ export default class SettingsModal extends React.Component {
 
   setConfigurationField = (e, { name, value }) => {
     this.setState({
-      configuration: {
-        ...this.state.configuration,
-        [name]: value,
+      config: {
+        ...this.state.config,
+        [name]: {
+          ...this.state.config[name],
+          value,
+        },
       },
       settings: this.state.settings,
     });
@@ -37,8 +39,7 @@ export default class SettingsModal extends React.Component {
     this.props.close();
   };
   render() {
-    const { settings, configuration, settingsList, configurationList } =
-      this.state;
+    const { config, settings, settingsList } = this.state;
 
     return (
       <>
@@ -46,7 +47,7 @@ export default class SettingsModal extends React.Component {
         <Modal.Content>
           <Form onSubmit={this.onSubmit} id="edit-settings">
             <Header as="h3" content="Settings" />
-            {settingsList.map((item) => {
+            {settingsList?.map((item) => {
               return (
                 <div key={item.key} style={{ marginBottom: '8px' }}>
                   <Form.Input
@@ -71,7 +72,7 @@ export default class SettingsModal extends React.Component {
             })}
             <Divider hidden />
             <Header as="h3" content="Configuration Keys" />
-            {configurationList.map((item) => {
+            {Object.values(config).map((item) => {
               return (
                 <Form.Input
                   key={item.key}
@@ -86,7 +87,7 @@ export default class SettingsModal extends React.Component {
                     </strong>
                   }
                   name={item.key}
-                  value={configuration[item.key]}
+                  value={item.value}
                   onChange={this.setConfigurationField}
                 />
               );

--- a/src/screens/Dashboard/index.js
+++ b/src/screens/Dashboard/index.js
@@ -216,23 +216,24 @@ export default class Home extends React.Component {
                 configuration={configuration}
                 settingsList={settingsList}
                 onSave={({ config, settings: savedSettings }) => {
-                  configuration.updateVariablesFromSimpleSettingsMap(config);
+                  if (
+                    settings.ocppConfiguration !==
+                    savedSettings.ocppConfiguration
+                  ) {
+                    const newConfiguration = getConfiguration(
+                      savedSettings.ocppConfiguration
+                    );
 
-                  // if (
-                  // 	settings.ocppConfiguration !==
-                  // 	savedSettings.ocppConfiguration
-                  // ) {
-                  // 	configList = getConfigurationList(
-                  // 		savedSettings.ocppConfiguration
-                  // 	);
-                  // 	config = getConfiguration(savedSettings.ocppConfiguration);
-                  // }
-
+                    this.setState({
+                      configuration: newConfiguration,
+                    });
+                    chargeStation.changeConfiguration(newConfiguration);
+                  } else {
+                    configuration.updateVariablesFromSimpleSettingsMap(config);
+                  }
                   this.setState(
                     {
                       settings: savedSettings,
-                      // configurationList: configList,
-                      // configuration: config,
                     },
                     () => {
                       chargeStation.options = savedSettings;

--- a/src/screens/Dashboard/index.js
+++ b/src/screens/Dashboard/index.js
@@ -10,7 +10,6 @@ import {
   getDefaultSession,
   ocppVersion,
   settingsList,
-  getConfigurationList,
 } from 'lib/settings';
 
 import chargeStationSvg from 'assets/charge-station.svg';
@@ -41,7 +40,6 @@ export default class Home extends React.Component {
     logEntries: [],
     session1OnceStarted: false,
     session2OnceStarted: false,
-    configurationList: getConfigurationList(ocppVersion()),
   };
 
   componentDidMount() {
@@ -95,7 +93,6 @@ export default class Home extends React.Component {
       inspectCommand,
       session1OnceStarted,
       session2OnceStarted,
-      configurationList,
     } = this.state;
     if (!chargeStation) {
       return <Loader />;
@@ -218,32 +215,26 @@ export default class Home extends React.Component {
                 settings={settings}
                 configuration={configuration}
                 settingsList={settingsList}
-                configurationList={configurationList}
-                onSave={({
-                  settings: savedSettings,
-                  configuration: savedConfiguration,
-                }) => {
-                  let configList = configurationList;
-                  let config = savedConfiguration;
+                onSave={({ config, settings: savedSettings }) => {
+                  configuration.updateVariablesFromSimpleSettingsMap(config);
 
-                  if (
-                    settings.ocppConfiguration !==
-                    savedSettings.ocppConfiguration
-                  ) {
-                    configList = getConfigurationList(
-                      savedSettings.ocppConfiguration
-                    );
-                    config = getConfiguration(savedSettings.ocppConfiguration);
-                  }
+                  // if (
+                  // 	settings.ocppConfiguration !==
+                  // 	savedSettings.ocppConfiguration
+                  // ) {
+                  // 	configList = getConfigurationList(
+                  // 		savedSettings.ocppConfiguration
+                  // 	);
+                  // 	config = getConfiguration(savedSettings.ocppConfiguration);
+                  // }
 
                   this.setState(
                     {
                       settings: savedSettings,
-                      configurationList: configList,
-                      configuration: config,
+                      // configurationList: configList,
+                      // configuration: config,
                     },
                     () => {
-                      chargeStation.configuration = config;
                       chargeStation.options = savedSettings;
                       chargeStation.disconnect();
                       setTimeout(() => {

--- a/src/screens/Dashboard/index.js
+++ b/src/screens/Dashboard/index.js
@@ -229,7 +229,9 @@ export default class Home extends React.Component {
                     });
                     chargeStation.changeConfiguration(newConfiguration);
                   } else {
-                    configuration.updateVariablesFromSimpleSettingsMap(config);
+                    configuration.updateVariablesFromSimpleConfigurationMap(
+                      config
+                    );
                   }
                   this.setState(
                     {

--- a/src/screens/Dashboard/index.js
+++ b/src/screens/Dashboard/index.js
@@ -229,9 +229,7 @@ export default class Home extends React.Component {
                     });
                     chargeStation.changeConfiguration(newConfiguration);
                   } else {
-                    configuration.updateVariablesFromSimpleConfigurationMap(
-                      config
-                    );
+                    configuration.updateVariablesFromKeyValueMap(config);
                   }
                   this.setState(
                     {


### PR DESCRIPTION
Configuration is now a class with common methods for OCPP 2.0.1 and 1.6.
The underlying data structure for those versions is different. For 2.0.1 this is not just a flat array of objects holding just the key values, but is closely modeled after the OCPP spec. (That way we can later do more advanced things like changing the non-Actual variable attributes).

Also added a handler for `SetVariables` message