### PR TITLE
 Always rebuild configuration on save  

### DIFF
--- a/src/screens/Dashboard/index.js
+++ b/src/screens/Dashboard/index.js
@@ -288,24 +288,16 @@ export default class Home extends React.Component {
                   });
                 }}
                 onSave={({ config, settings: savedSettings }) => {
-                  if (
-                    settings.ocppConfiguration !==
-                    savedSettings.ocppConfiguration
-                  ) {
-                    const newConfiguration = getConfiguration(
-                      savedSettings.ocppConfiguration,
-                      savedSettings,
-                    );
+                  const newConfiguration = getConfiguration(
+                    savedSettings.ocppConfiguration,
+                    savedSettings,
+                  );
 
-                    this.setState({
-                      configuration: newConfiguration,
-                    });
-                    newConfiguration.updateVariablesFromKeyValueMap(config);
-                    chargeStation.changeConfiguration(newConfiguration);
-                  } else {
-                    configuration.updateVariablesFromKeyValueMap(config);
-                    chargeStation.changeConfiguration(configuration);
-                  }
+                  this.setState({
+                    configuration: newConfiguration,
+                  });
+                  newConfiguration.updateVariablesFromKeyValueMap(config);
+                  chargeStation.changeConfiguration(newConfiguration);
                   chargeStation.save();
                   this.setState(
                     {


### PR DESCRIPTION
Some configuration options are conditional based on the model - so when changing the model, we need to get the configuration rebuilt in the same way we do when the protocol changes, otherwise the configuration options aren't visible.