### PR TITLE
Respect AuthorizeRemoteStart config option when starting a session

### DIFF
--- a/src/lib/ChargeStation/configurations/ads-tec-ocpp-16.ts
+++ b/src/lib/ChargeStation/configurations/ads-tec-ocpp-16.ts
@@ -1,9 +1,8 @@
 import { EventTypes as e } from '../eventHandlers/event-types';
 import DefaultOCPP16 from 'lib/ChargeStation/configurations/default-ocpp-16';
-import sendStartTransaction from 'lib/ChargeStation/eventHandlers/ocpp-16/send-start-transaction';
 import { ChargeStationEventHandler } from 'lib/ChargeStation/eventHandlers';
-import sendAuthorize from 'lib/ChargeStation/eventHandlers/ocpp-16/send-authorize';
 import { AuthorizationType } from 'lib/settings';
+import sendAuthorizeOrStartTransaction from 'lib/ChargeStation/eventHandlers/ocpp-16/send-authorize-or-start-transaction';
 
 const initiateSession: ChargeStationEventHandler = async (params) => {
   const { session, chargepoint } = params;
@@ -11,10 +10,9 @@ const initiateSession: ChargeStationEventHandler = async (params) => {
     session.options.uid = chargepoint.configuration.getVariableValue(
       'CreditIdToken'
     ) as string;
-    await sendStartTransaction(params);
-  } else {
-    await sendAuthorize(params);
+    session.options.skipAuthorize = true;
   }
+  return sendAuthorizeOrStartTransaction(params);
 };
 
 export default {

--- a/src/lib/ChargeStation/configurations/default-ocpp-16.ts
+++ b/src/lib/ChargeStation/configurations/default-ocpp-16.ts
@@ -5,7 +5,6 @@ import {
 import sendBootNotification from '../eventHandlers/ocpp-16/send-boot-notification';
 import sendHeartbeat from '../eventHandlers/ocpp-16/send-heartbeat';
 import sendHeartbeatDelayed from '../eventHandlers/ocpp-16/send-heartbeat-delayed';
-import sendAuthorize from '../eventHandlers/ocpp-16/send-authorize';
 import sendStopTransaction from '../eventHandlers/ocpp-16/send-stop-transaction';
 import handleTokenRejection from '../eventHandlers/ocpp-16/handle-token-rejection';
 import sendStartTransaction from '../eventHandlers/ocpp-16/send-start-transaction';
@@ -33,6 +32,7 @@ import handleDataTransfer from 'lib/ChargeStation/eventHandlers/ocpp-16/handle-d
 import handleGetInstalledCertificateIds from 'lib/ChargeStation/eventHandlers/ocpp-16/handle-get-installed-certificate-ids';
 import handleUpdateFirmwareReceived from '../eventHandlers/ocpp-16/handle-update-firmware-received';
 import handleTriggerMessageReceived from '../eventHandlers/ocpp-16/handle-trigger-message-received';
+import sendAuthorizeOrStartTransaction from 'lib/ChargeStation/eventHandlers/ocpp-16/send-authorize-or-start-transaction';
 
 // This is the default configuration for OCPP 1.6
 // Each key represents an event, and the value represents an array of handlers that will be called when the event is emitted
@@ -47,7 +47,7 @@ export default {
   ],
   [e.HeartbeatCallResultReceived]: [handleHeartbeatCallResultReceived],
   [e.HeartbeatAccepted]: [sendHeartbeatDelayed],
-  [e.SessionStartInitiated]: [sendAuthorize],
+  [e.SessionStartInitiated]: [sendAuthorizeOrStartTransaction],
   [e.SessionStopInitiated]: [sendStopTransaction],
   [e.AuthorizeCallResultReceived]: [handleAuthorizeCallResultReceived],
   [e.AuthorizationFailed]: [handleTokenRejection],

--- a/src/lib/ChargeStation/configurations/default-ocpp-20.ts
+++ b/src/lib/ChargeStation/configurations/default-ocpp-20.ts
@@ -29,6 +29,7 @@ import handleRequestStopTransaction from 'lib/ChargeStation/eventHandlers/ocpp-2
 import handleGetInstalledCertificateIds from 'lib/ChargeStation/eventHandlers/ocpp-20/handle-get-installed-certificate-ids';
 import handleUpdateFirmwareReceived from '../eventHandlers/ocpp-20/handle-update-firmware-received';
 import handleTriggerMessageReceived from '../eventHandlers/ocpp-20/handle-trigger-message-received';
+import sendAuthorizeOrStartTransaction from 'lib/ChargeStation/eventHandlers/ocpp-20/send-authorize-or-start-transaction';
 
 // This is the default configuration for OCPP 2.0.*
 // Each key represents an event, and the value represents an array of handlers that will be called when the event is emitted
@@ -43,7 +44,7 @@ export default {
   [e201.GetBaseReportReceived]: [handleGetBaseReportReceived],
   [e201.SetVariablesReceived]: [handleSetVariables],
   [e201.GetVariablesReceived]: [handleGetVariables],
-  [e.SessionStartInitiated]: [sendAuthorize],
+  [e.SessionStartInitiated]: [sendAuthorizeOrStartTransaction],
   [e.SessionStopInitiated]: [sendStopTransaction],
   [e.AuthorizeCallResultReceived]: [handleAuthorizeCallResultReceived],
   [e.AuthorizationFailed]: [handleTokenRejection],

--- a/src/lib/ChargeStation/configurations/e-totem-ocpp-16.ts
+++ b/src/lib/ChargeStation/configurations/e-totem-ocpp-16.ts
@@ -1,5 +1,4 @@
 import DefaultOCPP16 from 'lib/ChargeStation/configurations/default-ocpp-16';
-import sendAuthorize from 'lib/ChargeStation/eventHandlers/ocpp-16/send-authorize';
 import {
   EventTypes as e,
   EventTypes16 as e16,
@@ -12,10 +11,14 @@ import {
 import sendStatusNotificationFinishing from 'lib/ChargeStation/eventHandlers/ocpp-16/send-status-notification-finishing';
 import sendStatusNotificationAvailable from 'lib/ChargeStation/eventHandlers/ocpp-16/send-status-notification-available';
 import handleTransactionStoppedUI from 'lib/ChargeStation/eventHandlers/ocpp-16/handle-transaction-stopped-ui';
+import sendAuthorizeOrStartTransaction from 'lib/ChargeStation/eventHandlers/ocpp-16/send-authorize-or-start-transaction';
 
 export default {
   ...DefaultOCPP16,
-  [e.SessionStartInitiated]: [overrideSessionUid, sendAuthorize],
+  [e.SessionStartInitiated]: [
+    overrideSessionUid,
+    sendAuthorizeOrStartTransaction,
+  ],
   [e.DataTransferCallResultReceived]: [processDataTransferResult],
   [e16.StopTransactionAccepted]: [
     sendStatusNotificationFinishing,

--- a/src/lib/ChargeStation/configurations/sicharge-ocpp-16.ts
+++ b/src/lib/ChargeStation/configurations/sicharge-ocpp-16.ts
@@ -2,10 +2,13 @@ import { EventTypes as e } from '../eventHandlers/event-types';
 import DefaultOCPP16 from 'lib/ChargeStation/configurations/default-ocpp-16';
 import handleDataTransfer from 'lib/ChargeStation/eventHandlers/ocpp-16/sicharge/handle-data-transfer';
 import generateSessionUid from 'lib/ChargeStation/eventHandlers/ocpp-16/sicharge/generate-session-uid';
-import sendAuthorize from 'lib/ChargeStation/eventHandlers/ocpp-16/send-authorize';
+import sendAuthorizeOrStartTransaction from 'lib/ChargeStation/eventHandlers/ocpp-16/send-authorize-or-start-transaction';
 
 export default {
   ...DefaultOCPP16,
-  [e.SessionStartInitiated]: [generateSessionUid, sendAuthorize],
+  [e.SessionStartInitiated]: [
+    generateSessionUid,
+    sendAuthorizeOrStartTransaction,
+  ],
   [e.DataTransferReceived]: [handleDataTransfer],
 };

--- a/src/lib/ChargeStation/eventHandlers/index.ts
+++ b/src/lib/ChargeStation/eventHandlers/index.ts
@@ -4,7 +4,10 @@ import ChargeStation, { Session } from 'lib/ChargeStation';
 import { OCPPVersion } from 'lib/settings';
 import { Map } from '../../../types/generic';
 
-interface ChargeStationEventHandlerParams<CallBodyType, CallResultBodyType> {
+export interface ChargeStationEventHandlerParams<
+  CallBodyType,
+  CallResultBodyType,
+> {
   chargepoint: ChargeStation;
   emitter: ChargeStationEventEmitter;
   session: Session;

--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-remote-start-transaction.js
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-remote-start-transaction.js
@@ -15,6 +15,10 @@ export default async function handleRemoteStartTransaction({
   setTimeout(() => {
     chargepoint.startSession(Number(connectorId), {
       uid: idTag,
+      skipAuthorize:
+        chargepoint.configuration
+          .getVariableValue('AuthorizeRemoteTxRequests')
+          ?.toString() === 'false',
     });
   }, 100);
   response = {

--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/send-authorize-or-start-transaction.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/send-authorize-or-start-transaction.ts
@@ -1,0 +1,14 @@
+import { ChargeStationEventHandler } from 'lib/ChargeStation/eventHandlers';
+import sendAuthorize from 'lib/ChargeStation/eventHandlers/ocpp-16/send-authorize';
+import sendStartTransaction from 'lib/ChargeStation/eventHandlers/ocpp-16/send-start-transaction';
+
+const sendAuthorizeOrStartTransaction: ChargeStationEventHandler = async (
+  params
+) => {
+  if (params.session.options?.skipAuthorize !== true) {
+    return sendAuthorize(params);
+  }
+  return sendStartTransaction(params);
+};
+
+export default sendAuthorizeOrStartTransaction;

--- a/src/lib/ChargeStation/eventHandlers/ocpp-20/handle-request-start-transaction.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-20/handle-request-start-transaction.ts
@@ -22,6 +22,10 @@ const handleRequestStartTransaction: ChargeStationEventHandler<
           maxPowerKw: 0,
           uid: idToken.idToken,
           remoteStartId,
+          skipAuthorize:
+            chargepoint.configuration
+              .getVariableValue('AuthCtrlr.AuthorizeRemoteStart')
+              ?.toString() === 'false',
         },
         'rfid'
       );

--- a/src/lib/ChargeStation/eventHandlers/ocpp-20/send-authorize-or-start-transaction.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-20/send-authorize-or-start-transaction.ts
@@ -1,0 +1,25 @@
+import {
+  ChargeStationEventHandler,
+  ChargeStationEventHandlerParams,
+} from 'lib/ChargeStation/eventHandlers';
+import sendStartTransaction from 'lib/ChargeStation/eventHandlers/ocpp-20/send-start-transaction';
+import sendAuthorize from 'lib/ChargeStation/eventHandlers/ocpp-20/send-authorize';
+import { AuthorizeRequest } from 'schemas/ocpp/2.0/AuthorizeRequest';
+import { AuthorizeResponse } from 'schemas/ocpp/2.0/AuthorizeResponse';
+
+const sendAuthorizeOrStartTransaction: ChargeStationEventHandler = async (
+  params
+) => {
+  if (params.session.options?.skipAuthorize !== true) {
+    return sendAuthorize(
+      params as ChargeStationEventHandlerParams<
+        AuthorizeRequest,
+        AuthorizeResponse
+      >
+    );
+  }
+
+  return sendStartTransaction(params);
+};
+
+export default sendAuthorizeOrStartTransaction;

--- a/src/lib/ChargeStation/index.ts
+++ b/src/lib/ChargeStation/index.ts
@@ -441,6 +441,7 @@ interface SessionOptions {
   uid: string;
   authorizationType: AuthorizationType;
   remoteStartId?: number;
+  skipAuthorize?: boolean;
 }
 
 export class Session {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -195,7 +195,7 @@ export const sessionSettingsList: SettingsListSetting<SessionSetting>[] = [
 export interface Variable16 {
   key: string;
   description?: string;
-  value: string | number;
+  value: string | number | boolean;
   predicate?: (settings: Settings) => boolean;
 }
 
@@ -240,6 +240,12 @@ export const defaultVariableConfig16: Variable16[] = [
     key: 'Connector2-MaxCurrent',
     description: 'Meta data about max current on connector 2',
     value: 32,
+  },
+  {
+    key: 'AuthorizeRemoteTxRequests',
+    description:
+      'Whether a remote request to start a transaction should be authorized before start',
+    value: true,
   },
   {
     key: 'PaymentCurrency',


### PR DESCRIPTION
- new session option added, `skipAuthorize` - this is currently only set when the session is created via a remote/request start call
- `initiateSession` now invokes `sendAuthorizeOrStartTransaction()` instead of `sendAuthorize()` - the new function pays attention to the configuration value
- configuration option added for 1.6 (already covered for 2.0.1)