### PR TITLE
Fix running session check on remote start

### DIFF
--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-remote-start-transaction.js
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-remote-start-transaction.js
@@ -11,19 +11,20 @@ export default async function handleRemoteStartTransaction({
     response = {
       status: 'Rejected',
     };
+  } else {
+    setTimeout(() => {
+      chargepoint.startSession(Number(connectorId), {
+        uid: idTag,
+        skipAuthorize:
+          chargepoint.configuration
+            .getVariableValue('AuthorizeRemoteTxRequests')
+            ?.toString() === 'false',
+      });
+    }, 100);
+    response = {
+      status: 'Accepted',
+    };
   }
-  setTimeout(() => {
-    chargepoint.startSession(Number(connectorId), {
-      uid: idTag,
-      skipAuthorize:
-        chargepoint.configuration
-          .getVariableValue('AuthorizeRemoteTxRequests')
-          ?.toString() === 'false',
-    });
-  }, 100);
-  response = {
-    status: 'Accepted',
-  };
 
   chargepoint.writeCallResult(callMessageId, response);
 }

--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-remote-stop-transaction.js
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-remote-stop-transaction.js
@@ -20,13 +20,14 @@ export default async function handleRemoteStopTransaction({
     response = {
       status: 'Rejected',
     };
+  } else {
+    setTimeout(() => {
+      chargepoint.stopSession(Number(connectorId));
+    }, 100);
+    response = {
+      status: 'Accepted',
+    };
   }
-  setTimeout(() => {
-    chargepoint.stopSession(Number(connectorId));
-  }, 100);
-  response = {
-    status: 'Accepted',
-  };
 
   chargepoint.writeCallResult(callMessageId, response);
 }

--- a/src/lib/ChargeStation/eventHandlers/ocpp-20/handle-request-start-transaction.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-20/handle-request-start-transaction.ts
@@ -7,10 +7,12 @@ const handleRequestStartTransaction: ChargeStationEventHandler<
 > = ({ chargepoint, callMessageId, callMessageBody }) => {
   const { remoteStartId, evseId, idToken } = callMessageBody;
 
-  let response: RequestStartTransactionResponse = { status: 'Accepted' };
+  let response: RequestStartTransactionResponse;
 
   if (chargepoint.hasRunningSession(Number(evseId))) {
-    response = { status: 'Rejected' };
+    response = {
+      status: 'Rejected',
+    };
   } else {
     setTimeout(() => {
       chargepoint.startSession(
@@ -30,6 +32,9 @@ const handleRequestStartTransaction: ChargeStationEventHandler<
         'rfid'
       );
     }, 100);
+    response = {
+      status: 'Accepted',
+    };
   }
 
   chargepoint.writeCallResult(callMessageId, response);

--- a/src/lib/ChargeStation/eventHandlers/ocpp-20/handle-request-stop-transaction.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-20/handle-request-stop-transaction.ts
@@ -7,7 +7,7 @@ const handleRequestStopTransaction: ChargeStationEventHandler<
 > = ({ chargepoint, callMessageId, callMessageBody }) => {
   const { transactionId } = callMessageBody;
 
-  let response: RequestStopTransactionResponse = { status: 'Accepted' };
+  let response: RequestStopTransactionResponse;
 
   const connectorId = ['1', '2'].find(
     (cId) =>
@@ -18,13 +18,14 @@ const handleRequestStopTransaction: ChargeStationEventHandler<
     response = {
       status: 'Rejected',
     };
+  } else {
+    setTimeout(() => {
+      chargepoint.stopSession(Number(connectorId));
+    }, 100);
+    response = {
+      status: 'Accepted',
+    };
   }
-  setTimeout(() => {
-    chargepoint.stopSession(Number(connectorId));
-  }, 100);
-  response = {
-    status: 'Accepted',
-  };
 
   chargepoint.writeCallResult(callMessageId, response);
 };


### PR DESCRIPTION
When there is already a session against the connector, a session was always being started for 1.6. The same type of issue also existed for remote stop (both OCPP versions)