### PR TITLE
Fix handling of token rejection for authorize and start transaction

### DIFF
--- a/src/lib/ChargeStation/configurations/default-ocpp-16.ts
+++ b/src/lib/ChargeStation/configurations/default-ocpp-16.ts
@@ -53,7 +53,8 @@ export default {
   [e.AuthorizeCallResultReceived]: [handleAuthorizeCallResultReceived],
   [e.AuthorizationFailed]: [handleTokenRejection],
   [e.AuthorizationAccepted]: [sendStartTransaction],
-  [e16.AuthorizationFailedDuringStartTransaction]: [handleTokenRejection],
+  [e.AuthorizationFailedDuringTransactionStart]: [handleTokenRejection],
+  [e.AuthorizationFailedDuringTransactionStop]: [handleTokenRejection],
   [e16.StartTransactionCallResultReceived]: [
     handleStartTransactionCallResultReceived,
   ],

--- a/src/lib/ChargeStation/configurations/default-ocpp-20.ts
+++ b/src/lib/ChargeStation/configurations/default-ocpp-20.ts
@@ -48,6 +48,8 @@ export default {
   [e.SessionStopInitiated]: [sendStopTransaction],
   [e.AuthorizeCallResultReceived]: [handleAuthorizeCallResultReceived],
   [e.AuthorizationFailed]: [handleTokenRejection],
+  [e.AuthorizationFailedDuringTransactionStart]: [handleTokenRejection],
+  [e.AuthorizationFailedDuringTransactionStop]: [handleTokenRejection],
   [e.SessionCancelled]: [sendStatusNotification],
   [e.AuthorizationAccepted]: [sendStartTransaction],
   [e201.TransactionEventCallResultReceived]: [

--- a/src/lib/ChargeStation/eventHandlers/event-types.js
+++ b/src/lib/ChargeStation/eventHandlers/event-types.js
@@ -13,7 +13,11 @@ export const EventTypes = {
   AuthorizationFailed: 'authorizationFailed',
   AuthorizationAccepted: 'authorizationAccepted',
   AuthorizeCallResultReceived: 'authorizeCallResultReceived',
-  ChargingLimitReached: 'charingLimitReached',
+  AuthorizationFailedDuringTransactionStart:
+    'authorizationFailedDuringTransactionStart',
+  AuthorizationFailedDuringTransactionStop:
+    'authorizationFailedDuringTransactionStop',
+  ChargingLimitReached: 'chargingLimitReached',
   ChargingTick: 'chargingTick',
   ResetReceived: 'resetReceived',
   SetChargingProfileReceived: 'setChargingProfileReceived',
@@ -26,10 +30,6 @@ export const EventTypes = {
 
 // OCPP 1.6 specific events
 export const EventTypes16 = {
-  AuthorizationFailedDuringStartTransaction:
-    'authorizationFailedDuringStartTransaction',
-  AuthorizationFailedDuringStopTransaction:
-    'authorizationFailedDuringStopTransaction',
   StartTransactionAccepted: 'startTransactionAccepted',
   StopTransactionAccepted: 'stopTransactionAccepted',
   GetConfigurationReceived: 'getConfigurationReceived',

--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-authorize-call-result-received.js
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-authorize-call-result-received.js
@@ -5,9 +5,9 @@ export default async function handleAuthorizeCallResultReceived({
   session,
   callResultMessageBody,
 }) {
-  if (callResultMessageBody.idTagInfo.status === 'Invalid') {
+  if (callResultMessageBody.idTagInfo.status !== 'Accepted') {
     emitter.emitEvent(EventTypes.AuthorizationFailed, { session });
-    alert('RFID card UID is invalid');
+    alert('Token UID was not accepted');
     return;
   }
 

--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-start-transaction-call-result-received.js
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-start-transaction-call-result-received.js
@@ -1,4 +1,4 @@
-import { EventTypes16 } from '../event-types';
+import { EventTypes, EventTypes16 } from '../event-types';
 
 export default async function handleStartTransactionCallResultReceived({
   emitter,
@@ -6,14 +6,8 @@ export default async function handleStartTransactionCallResultReceived({
   session,
   chargepoint,
 }) {
-  if (callResultMessageBody.idTagInfo.status === 'Invalid') {
-    emitter.emitEvent(EventTypes16.AuthorizationFailedDuringStartTransaction, {
-      session,
-    });
-    return;
-  }
-  if (callResultMessageBody.idTagInfo.status === 'ConcurrentTx') {
-    emitter.emitEvent(EventTypes16.AuthorizationFailedDuringStartTransaction, {
+  if (callResultMessageBody.idTagInfo.status !== 'Accepted') {
+    emitter.emitEvent(EventTypes.AuthorizationFailedDuringTransactionStart, {
       session,
     });
     return;

--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-stop-transaction-call-result-received.js
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-stop-transaction-call-result-received.js
@@ -1,11 +1,17 @@
-import { EventTypes16 } from '../event-types';
+import { EventTypes, EventTypes16 } from '../event-types';
 
 export default async function handleStopTransactionCallResultReceived({
   emitter,
+  callResultMessageBody,
   session,
   chargepoint,
 }) {
-  // TODO: Listen for rejections
+  if (callResultMessageBody.idTagInfo.status !== 'Accepted') {
+    emitter.emitEvent(EventTypes.AuthorizationFailedDuringTransactionStop, {
+      session,
+    });
+    return;
+  }
 
   delete chargepoint.sessions[session.connectorId];
 

--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-token-rejection.js
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-token-rejection.js
@@ -6,7 +6,7 @@ export default async function handleTokenRejection({
   emitter,
   session,
 }) {
-  if (chargepoint.sessions[session.connectorId]) {
+  if (!chargepoint.sessions[session.connectorId]) {
     return;
   }
 

--- a/src/lib/ChargeStation/eventHandlers/ocpp-20/handle-authorize-call-result-received.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-20/handle-authorize-call-result-received.ts
@@ -9,7 +9,7 @@ const handleAuthorizeCallResultReceived: ChargeStationEventHandler<
 > = ({ emitter, session, callResultMessageBody }) => {
   if (callResultMessageBody.idTokenInfo.status !== 'Accepted') {
     emitter.emitEvent(EventTypes.AuthorizationFailed, { session });
-    alert('RFID card UID is invalid');
+    alert('Token UID was not accepted');
     return;
   }
 


### PR DESCRIPTION
Numerous issues:

- the simulator would continue to charge if `Blocked` status was returned - we now stop if the value is anything but `Accepted`
- the token rejection handler had the condition wrong when checking for an active session on the connector (this fixes a long standing issue where a connector remains unavailable after using an invalid token)
- 2.0.1 side wasn't implementing any event handling around token rejection; instead the status notification write was inlined