### PR TITLE
[HW-1352] Fix updating variables for OCPP2.0.1.

### DIFF
--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -928,7 +928,7 @@ class VariableConfiguration201 implements VariableConfiguration<Variable201> {
         variableAttribute: [
           {
             type: variable.attributeType,
-            value: variable.attributeValue,
+            value: variable.attributeValue.toString(),
           },
         ],
       };
@@ -942,13 +942,13 @@ class VariableConfiguration201 implements VariableConfiguration<Variable201> {
     if (varAttrIndex === -1) {
       this.variables[key].variableAttribute.push({
         type: variable.attributeType,
-        value: variable.attributeValue,
+        value: variable.attributeValue.toString(),
       });
       return;
     }
 
     this.variables[key].variableAttribute[varAttrIndex].value =
-      variable.attributeValue;
+      variable.attributeValue.toString();
   }
 
   getVariableActualValue(key: string): string {


### PR DESCRIPTION
As CS suppose to store configuration in strings, setting integer caused an issue:

<img width="1161" alt="Screenshot 2025-01-28 at 17 10 15" src="https://github.com/user-attachments/assets/8bb449e4-c0eb-469f-8156-25c7aad3faad" />
