### PR TITLE
Avoid issues with numeric charging station settings

### DIFF
--- a/src/lib/ChargeStation/index.ts
+++ b/src/lib/ChargeStation/index.ts
@@ -20,7 +20,7 @@ import clock, { Interval } from './clock';
 export interface Settings {
   ocppConfiguration: string;
   ocppBaseUrl: string;
-  interactiveMessagesReply: string;
+  interactiveMessagesReply: boolean;
   chargePointVendor: string;
   chargePointModel: string;
   chargePointSerialNumber: string;
@@ -170,7 +170,7 @@ export default class ChargeStation {
         request: { method, params: body },
       };
 
-      if (this.settings.interactiveMessagesReply === 'true') {
+      if (this.settings.interactiveMessagesReply) {
         this.callToReplyManually = { messageId, action: method, payload: body };
       } else {
         this.emitter.emitEvent(`${toCamelCase(method)}Received`, {

--- a/src/lib/ChargeStation/index.ts
+++ b/src/lib/ChargeStation/index.ts
@@ -535,6 +535,11 @@ export class Session {
       this.carBatteryStateOfCharge +=
         (amountKwhToCharge / this.carBatteryKwh) * 100;
 
+      this.carBatteryStateOfCharge = Math.min(
+        this.carBatteryStateOfCharge,
+        100
+      );
+
       const carNeededKwh =
         this.carBatteryKwh -
         this.carBatteryKwh * (this.carBatteryStateOfCharge / 100);

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -32,7 +32,7 @@ export enum SessionSetting {
 export interface SettingsListSetting<T> {
   key: T;
   name: string;
-  type?: undefined | 'dropdown';
+  type?: undefined | 'number' | 'dropdown';
   options?: undefined | string[];
   description: string;
   defaultValue: string | number;
@@ -195,6 +195,7 @@ export const sessionSettingsList: SettingsListSetting<SessionSetting>[] = [
     description:
       'The power in kW that this charge startion can deliver to a car (e.g. AC single phase is 7.4kW, AC three phase is 22kW, DC Fast charger is 25-175kW',
     defaultValue: 75,
+    type: 'number',
   },
   {
     key: SessionSetting.carBatteryKwh,
@@ -202,6 +203,7 @@ export const sessionSettingsList: SettingsListSetting<SessionSetting>[] = [
     description:
       "The car battery capacity that we're simulating in kWh - is used for determinig when to flatten MeterValues and send SuspendedEV notice",
     defaultValue: 64,
+    type: 'number',
   },
   {
     key: SessionSetting.carBatteryStateOfCharge,
@@ -209,6 +211,7 @@ export const sessionSettingsList: SettingsListSetting<SessionSetting>[] = [
     description:
       'How full is the car battery we are simulating - is used for determinig when to flatten MeterValues and send SuspendedEV notice',
     defaultValue: 80,
+    type: 'number',
   },
 ];
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -33,10 +33,10 @@ export interface SettingsListSetting<T> {
   key: T;
   name: string;
   input?: 'text' | 'dropdown';
-  type?: 'string' | 'number';
+  type?: 'string' | 'number' | 'boolean';
   options?: undefined | string[];
   description: string;
-  defaultValue: string | number;
+  defaultValue: string | number | boolean;
   predicate?: (settings: Settings) => boolean;
 }
 
@@ -85,7 +85,8 @@ export const settingsList: SettingsListSetting<ChargeStationSetting>[] = [
       'If a modal will open to reply every message received by the charge station',
     input: 'dropdown',
     options: ['true', 'false'],
-    defaultValue: 'false',
+    defaultValue: false,
+    type: 'boolean',
   },
   {
     key: ChargeStationSetting.ChargePointVendor,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -32,7 +32,8 @@ export enum SessionSetting {
 export interface SettingsListSetting<T> {
   key: T;
   name: string;
-  type?: undefined | 'number' | 'dropdown';
+  input?: 'text' | 'dropdown';
+  type?: 'string' | 'number';
   options?: undefined | string[];
   description: string;
   defaultValue: string | number;
@@ -65,7 +66,7 @@ const isEVBox = (settings: Settings) => settings.chargePointModel === 'evbox';
 export const settingsList: SettingsListSetting<ChargeStationSetting>[] = [
   {
     key: ChargeStationSetting.OCPPConfiguration,
-    type: 'dropdown',
+    input: 'dropdown',
     options: [OCPPVersion.ocpp16, OCPPVersion.ocpp201],
     name: 'OCPP Configuration',
     description: 'OCPP Configuration to use (ocpp1.6 or ocpp2.0.1)',
@@ -82,7 +83,7 @@ export const settingsList: SettingsListSetting<ChargeStationSetting>[] = [
     name: 'Interactive Messages Reply',
     description:
       'If a modal will open to reply every message received by the charge station',
-    type: 'dropdown',
+    input: 'dropdown',
     options: ['true', 'false'],
     defaultValue: 'false',
   },
@@ -124,7 +125,7 @@ export const settingsList: SettingsListSetting<ChargeStationSetting>[] = [
   },
   {
     key: ChargeStationSetting.ETotemTerminalMode,
-    type: 'dropdown',
+    input: 'dropdown',
     options: ['etotem', 'etotem_offline'],
     name: 'e-Totem Payment Terminal Mode',
     description: 'Whether online or offline cost calculations should be used',
@@ -133,7 +134,7 @@ export const settingsList: SettingsListSetting<ChargeStationSetting>[] = [
   },
   {
     key: ChargeStationSetting.ETotemCostCalculationMode,
-    type: 'dropdown',
+    input: 'dropdown',
     options: ['Legacy', 'DureeConsoReelleSession', 'DureeConsoSession'],
     name: 'e-Totem Offline Cost Calculation',
     description: 'The mode of calculating offline session costs',
@@ -195,7 +196,7 @@ export const sessionSettingsList: SettingsListSetting<SessionSetting>[] = [
     description:
       'The power in kW that this charge startion can deliver to a car (e.g. AC single phase is 7.4kW, AC three phase is 22kW, DC Fast charger is 25-175kW',
     defaultValue: 75,
-    type: 'number',
+    input: 'number',
   },
   {
     key: SessionSetting.carBatteryKwh,
@@ -203,7 +204,7 @@ export const sessionSettingsList: SettingsListSetting<SessionSetting>[] = [
     description:
       "The car battery capacity that we're simulating in kWh - is used for determinig when to flatten MeterValues and send SuspendedEV notice",
     defaultValue: 64,
-    type: 'number',
+    input: 'number',
   },
   {
     key: SessionSetting.carBatteryStateOfCharge,
@@ -211,7 +212,7 @@ export const sessionSettingsList: SettingsListSetting<SessionSetting>[] = [
     description:
       'How full is the car battery we are simulating - is used for determinig when to flatten MeterValues and send SuspendedEV notice',
     defaultValue: 80,
-    type: 'number',
+    input: 'number',
   },
 ];
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -197,7 +197,7 @@ export const sessionSettingsList: SettingsListSetting<SessionSetting>[] = [
     description:
       'The power in kW that this charge startion can deliver to a car (e.g. AC single phase is 7.4kW, AC three phase is 22kW, DC Fast charger is 25-175kW',
     defaultValue: 75,
-    input: 'number',
+    type: 'number',
   },
   {
     key: SessionSetting.carBatteryKwh,
@@ -205,7 +205,7 @@ export const sessionSettingsList: SettingsListSetting<SessionSetting>[] = [
     description:
       "The car battery capacity that we're simulating in kWh - is used for determinig when to flatten MeterValues and send SuspendedEV notice",
     defaultValue: 64,
-    input: 'number',
+    type: 'number',
   },
   {
     key: SessionSetting.carBatteryStateOfCharge,
@@ -213,7 +213,7 @@ export const sessionSettingsList: SettingsListSetting<SessionSetting>[] = [
     description:
       'How full is the car battery we are simulating - is used for determinig when to flatten MeterValues and send SuspendedEV notice',
     defaultValue: 80,
-    input: 'number',
+    type: 'number',
   },
 ];
 

--- a/src/screens/Dashboard/SettingsInput.tsx
+++ b/src/screens/Dashboard/SettingsInput.tsx
@@ -1,0 +1,61 @@
+import { SettingsListSetting } from 'lib/settings';
+import { Form } from 'semantic';
+import { HelpTip } from 'components';
+import React from 'react';
+
+interface Props<T> {
+  item: SettingsListSetting<T>;
+  value?: string;
+  onChange: (
+    event: React.SyntheticEvent<HTMLElement, Event>,
+    data: { name?: string; value?: unknown }
+  ) => void;
+}
+
+export default function SettingsInput<T>({ item, value, onChange }: Props<T>) {
+  return (
+    <>
+      {item.type === 'dropdown' ? (
+        <Form.Select
+          key={item.key?.toString()}
+          label={
+            <strong
+              style={{
+                marginBottom: '4px',
+                display: 'inline-block',
+              }}>
+              {item.name}
+              {item.description && <HelpTip text={item.description} />}
+            </strong>
+          }
+          options={item.options?.map((i) => ({ text: i, value: i })) || []}
+          name={item.key}
+          value={value}
+          onChange={onChange}
+        />
+      ) : (
+        <Form.Input
+          key={item.key?.toString()}
+          label={
+            <strong
+              style={{
+                marginBottom: '4px',
+                display: 'inline-block',
+              }}>
+              {item.name}
+              {item.description && <HelpTip text={item.description} />}
+            </strong>
+          }
+          name={item.key}
+          value={value}
+          onChange={(e, { name, value }) =>
+            onChange(e, {
+              name,
+              value: item.type === 'number' ? Number(value) : value,
+            })
+          }
+        />
+      )}
+    </>
+  );
+}

--- a/src/screens/Dashboard/SettingsInput.tsx
+++ b/src/screens/Dashboard/SettingsInput.tsx
@@ -12,10 +12,23 @@ interface Props<T> {
   ) => void;
 }
 
+const castValue = (type: string | undefined, value: unknown): unknown => {
+  return type === 'number' ? Number(value) : value;
+};
+
 export default function SettingsInput<T>({ item, value, onChange }: Props<T>) {
+  const handleChange = (
+    e: React.SyntheticEvent<HTMLElement, Event>,
+    { name, value }: { name?: string; value?: unknown }
+  ) =>
+    onChange(e, {
+      name,
+      value: castValue(item.type, value),
+    });
+
   return (
     <>
-      {item.type === 'dropdown' ? (
+      {item.input === 'dropdown' ? (
         <Form.Select
           key={item.key?.toString()}
           label={
@@ -31,7 +44,7 @@ export default function SettingsInput<T>({ item, value, onChange }: Props<T>) {
           options={item.options?.map((i) => ({ text: i, value: i })) || []}
           name={item.key}
           value={value}
-          onChange={onChange}
+          onChange={handleChange}
         />
       ) : (
         <Form.Input
@@ -48,12 +61,7 @@ export default function SettingsInput<T>({ item, value, onChange }: Props<T>) {
           }
           name={item.key}
           value={value}
-          onChange={(e, { name, value }) =>
-            onChange(e, {
-              name,
-              value: item.type === 'number' ? Number(value) : value,
-            })
-          }
+          onChange={handleChange}
         />
       )}
     </>

--- a/src/screens/Dashboard/SettingsInput.tsx
+++ b/src/screens/Dashboard/SettingsInput.tsx
@@ -13,7 +13,15 @@ interface Props<T> {
 }
 
 const castValue = (type: string | undefined, value: unknown): unknown => {
-  return type === 'number' ? Number(value) : value;
+  switch (type) {
+    case 'number':
+      return Number(value);
+    case 'boolean':
+      return value === 'true';
+    case 'string':
+    default:
+      return value;
+  }
 };
 
 export default function SettingsInput<T>({ item, value, onChange }: Props<T>) {

--- a/src/screens/Dashboard/SettingsModal.js
+++ b/src/screens/Dashboard/SettingsModal.js
@@ -3,6 +3,7 @@ import { Modal, Button, Form, Header, Divider } from 'semantic';
 import modal from 'helpers/modal';
 import { HelpTip } from 'components';
 import { ChargeStationSetting } from 'lib/settings';
+import SettingsInput from 'screens/Dashboard/SettingsInput';
 
 @modal
 export default class SettingsModal extends React.Component {
@@ -63,49 +64,16 @@ export default class SettingsModal extends React.Component {
             {settingsList?.map((item) => {
               return (
                 <div key={item.key} style={{ marginBottom: '8px' }}>
-                  {item.type === 'dropdown' ? (
-                    <Form.Select
-                      label={
-                        <strong
-                          style={{
-                            marginBottom: '4px',
-                            display: 'inline-block',
-                          }}>
-                          {item.name}
-                          {item.description && (
-                            <HelpTip text={item.description} />
-                          )}
-                        </strong>
+                  <SettingsInput
+                    item={item}
+                    value={settings[item.key]?.toString()}
+                    onChange={(e, { name, value }) => {
+                      if (name === 'ocppConfiguration') {
+                        this.props.onProtocolChange(value);
                       }
-                      options={item.options.map((i) => ({ text: i, value: i }))}
-                      name={item.key}
-                      value={settings[item.key]}
-                      onChange={(e, { name, value }) => {
-                        if (name === 'ocppConfiguration') {
-                          this.props.onProtocolChange(value);
-                        }
-                        this.setSettingsField(e, { name, value });
-                      }}
-                    />
-                  ) : (
-                    <Form.Input
-                      label={
-                        <strong
-                          style={{
-                            marginBottom: '4px',
-                            display: 'inline-block',
-                          }}>
-                          {item.name}
-                          {item.description && (
-                            <HelpTip text={item.description} />
-                          )}
-                        </strong>
-                      }
-                      name={item.key}
-                      value={settings[item.key]}
-                      onChange={this.setSettingsField}
-                    />
-                  )}
+                      this.setSettingsField(e, { name, value });
+                    }}
+                  />
                 </div>
               );
             })}
@@ -113,19 +81,12 @@ export default class SettingsModal extends React.Component {
             <Header as="h3" content="Configuration Keys" />
             {Object.values(config).map((item) => {
               return (
-                <Form.Input
+                <SettingsInput
                   key={item.key}
-                  label={
-                    <strong
-                      style={{
-                        marginBottom: '4px',
-                        display: 'inline-block',
-                      }}>
-                      {item.key}
-                      {item?.description && <HelpTip text={item.description} />}
-                    </strong>
-                  }
-                  name={item.key}
+                  item={{
+                    ...item,
+                    name: item.key,
+                  }}
                   value={item.value}
                   onChange={this.setConfigurationField}
                 />

--- a/src/screens/Dashboard/StartSessionModal.js
+++ b/src/screens/Dashboard/StartSessionModal.js
@@ -2,11 +2,7 @@ import React from 'react';
 import { Modal, Button, Form, Header, Divider } from 'semantic';
 import modal from 'helpers/modal';
 import { AuthorizationType, sessionSettingsList } from 'lib/settings';
-import { HelpTip } from 'components';
 import SettingsInput from 'screens/Dashboard/SettingsInput';
-
-const convertValue = (item, value) =>
-  item.type === 'number' ? Number(value) : value;
 
 @modal
 export default class StartSessionModal extends React.Component {

--- a/src/screens/Dashboard/StartSessionModal.js
+++ b/src/screens/Dashboard/StartSessionModal.js
@@ -3,6 +3,10 @@ import { Modal, Button, Form, Header, Divider } from 'semantic';
 import modal from 'helpers/modal';
 import { AuthorizationType, sessionSettingsList } from 'lib/settings';
 import { HelpTip } from 'components';
+import SettingsInput from 'screens/Dashboard/SettingsInput';
+
+const convertValue = (item, value) =>
+  item.type === 'number' ? Number(value) : value;
 
 @modal
 export default class StartSessionModal extends React.Component {
@@ -23,6 +27,7 @@ export default class StartSessionModal extends React.Component {
     this.props.onSave(this.state);
     this.props.close();
   };
+
   render() {
     const { session, connectorId, authorizationType } = this.state;
     const { availableConnectors } = this.props;
@@ -76,21 +81,9 @@ export default class StartSessionModal extends React.Component {
                 {sessionSettingsList.map((item) => {
                   return (
                     <div key={item.key} style={{ marginBottom: '8px' }}>
-                      <Form.Input
-                        label={
-                          <strong
-                            style={{
-                              marginBottom: '4px',
-                              display: 'inline-block',
-                            }}>
-                            {item.name}
-                            {item.description && (
-                              <HelpTip text={item.description} />
-                            )}
-                          </strong>
-                        }
-                        name={item.key}
-                        value={session[item.key]}
+                      <SettingsInput
+                        item={item}
+                        value={session[item.key]?.toString()}
                         onChange={this.setField}
                       />
                     </div>


### PR DESCRIPTION
There is currently an issue when numeric values are changed.. e.g. state of charge. These gets passed down to the Session class as string values, and because JS, the handling of these is not correct.

For example with stateOfCharge = `"50"`

```
      this.carBatteryStateOfCharge +=
        (amountKwhToCharge / this.carBatteryKwh) * 100;
```

can result in a value looking like `"500.103983101"`.

I've extracted out the common input handling elements into a separate component which ensures numeric values are cast before passing to any onChange handlers.