### PR TITLE
Use UTC clock

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@babel/preset-typescript": "^7.24.6",
     "@bedrockio/config": "^2.0.4",
     "@bedrockio/instrumentation": "^1.4.14",
+    "@date-fns/utc": "^2.1.0",
     "@draft-js-plugins/alignment": "^5.0.2",
     "@draft-js-plugins/anchor": "^4.1.3",
     "@draft-js-plugins/drag-n-drop": "^4.2.1",

--- a/src/lib/ChargeStation/clock.ts
+++ b/src/lib/ChargeStation/clock.ts
@@ -1,10 +1,12 @@
 // Class representing clock, used to enable 'time travel' in the simulation
+import { UTCDate } from '@date-fns/utc';
+
 class Clock {
-  protected nowDate: Date;
+  protected nowDate: UTCDate;
   protected clockInterval;
 
   constructor(protected speed = 1) {
-    this.nowDate = new Date();
+    this.nowDate = new UTCDate();
     this.clockInterval = setInterval(() => {
       this.nowDate.setTime(this.nowDate.getTime() + 1000 * this.speed);
     }, 1000);
@@ -23,15 +25,15 @@ class Clock {
   }
 
   public reset() {
-    this.setNow(new Date());
+    this.setNow(new UTCDate());
   }
 
-  public setNow(date: Date) {
+  public setNow(date: UTCDate) {
     this.nowDate = date;
   }
 
   public now() {
-    return new Date(this.nowDate);
+    return new UTCDate(this.nowDate);
   }
 
   public setInterval(

--- a/src/screens/Dashboard/SetDateTimeModal.js
+++ b/src/screens/Dashboard/SetDateTimeModal.js
@@ -5,7 +5,8 @@ import { Modal, Button } from 'semantic';
 import { DayPicker } from 'react-day-picker';
 
 import modal from 'helpers/modal';
-import { getHours, getMinutes, setHours, setMinutes } from 'date-fns';
+import { UTCDate } from '@date-fns/utc';
+import { setHours, setMinutes } from 'date-fns';
 import { Form } from 'semantic-ui-react';
 
 @modal
@@ -45,10 +46,10 @@ export default class SetDateTimeModal extends React.Component {
       const [hours, minutes] = time.split(':').map((str) => parseInt(str, 10));
       this.setState({
         ...this.state,
-        date: new Date(
-          newDate.getFullYear(),
-          newDate.getMonth(),
-          newDate.getDate(),
+        date: new UTCDate(
+          newDate.getUTCFullYear(),
+          newDate.getUTCMonth(),
+          newDate.getUTCDate(),
           hours,
           minutes
         ),
@@ -61,6 +62,7 @@ export default class SetDateTimeModal extends React.Component {
         <Modal.Content>
           <Form onSubmit={this.onSubmit} id="set-date-time-form">
             <DayPicker
+              timeZone={'UTC'}
               animate
               mode="single"
               selected={date}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1391,6 +1391,11 @@
   resolved "https://registry.yarnpkg.com/@date-fns/tz/-/tz-1.2.0.tgz#81cb3211693830babaf3b96aff51607e143030a6"
   integrity sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==
 
+"@date-fns/utc@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@date-fns/utc/-/utc-2.1.0.tgz#923896160bd33209d747503eeed59005ee4425d2"
+  integrity sha512-176grgAgU2U303rD2/vcOmNg0kGPbhzckuH1TEP2al7n0AQipZIy9P15usd2TKQCG1g+E1jX/ZVQSzs4sUDwgA==
+
 "@discoveryjs/json-ext@0.5.7", "@discoveryjs/json-ext@^0.5.0":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"


### PR DESCRIPTION
If your local TZ is not UTC, things get a bit confusing when adjusting the date and time, because the OCPP payloads end up converting the current time to UTC (i.e. it _looks_ different to what you've just set). I think generally it would be simpler if UTC is used everywhere, particularly as the times in tariffs are UTC.