### PR TITLE
Tick clock forward more frequently

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "postcss-loader": "^5.1.0",
     "prop-types": "^15.7.2",
     "qr.js": "^0.0.0",
-    "queue-promise": "^2.2.1",
     "react": "^17.0.2",
     "react-day-picker": "^9.6.2",
     "react-dom": "^17.0.2",

--- a/src/lib/ChargeStation/clock.ts
+++ b/src/lib/ChargeStation/clock.ts
@@ -6,8 +6,8 @@ class Clock {
   constructor(protected speed = 1) {
     this.nowDate = new Date();
     this.clockInterval = setInterval(() => {
-      this.nowDate.setTime(this.nowDate.getTime() + 1000 * this.speed);
-    }, 1000);
+      this.nowDate.setTime(this.nowDate.getTime() + 100 * this.speed);
+    }, 100);
   }
 
   public setSpeed(speed: number) {

--- a/src/lib/ChargeStation/connection.ts
+++ b/src/lib/ChargeStation/connection.ts
@@ -1,4 +1,4 @@
-import Queue from 'queue-promise';
+import PromiseQueue from 'lib/ChargeStation/queue';
 
 enum MessageType {
   CALL = 2,
@@ -21,7 +21,7 @@ class Connection {
   private version: string;
   private ready: boolean;
   private messageId: number;
-  private callQueue: Queue;
+  private callQueue: PromiseQueue;
   private inflight: Inflight | undefined; // the call queue should guarantee only 1 inflight call at any point in time
   private inflightTimeoutMs: number = 10000; // time before we consider the inflight call lost
   onConnected: null | (() => unknown);
@@ -43,7 +43,7 @@ class Connection {
     this.version = version;
     this.ready = false;
     this.messageId = 1;
-    this.callQueue = new Queue({ concurrent: 1, interval: 50 });
+    this.callQueue = new PromiseQueue();
     this.onConnected = null;
 
     const url = this.ocppBaseUrl + '/' + this.ocppIdentity;

--- a/src/lib/ChargeStation/queue.ts
+++ b/src/lib/ChargeStation/queue.ts
@@ -1,0 +1,9 @@
+export default class PromiseQueue {
+  private queue: Promise<void> = Promise.resolve();
+
+  enqueue(operation: () => Promise<void>) {
+    return new Promise((resolve, reject) => {
+      this.queue = this.queue.then(operation).then(resolve).catch(reject);
+    });
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8028,11 +8028,6 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-queue-promise@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/queue-promise/-/queue-promise-2.2.1.tgz#8de03fb79ba458efcb5ebf76368ab029d2669752"
-  integrity sha512-C3eyRwLF9m6dPV4MtqMVFX+Xmc7keZ9Ievm3jJ/wWM5t3uVbFnGsJXwpYzZ4LaIEcX9bss/mdaKzyrO6xheRuA==
-
 quick-format-unescaped@^4.0.3:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz#93ef6dd8d3453cbc7970dd614fad4c5954d6b5a7"


### PR DESCRIPTION
With the dynamic speed controls, setting a speed of e.g. 200x results in time moving forward in multi-minute chunks, yet we have requirements to send e.g. meter values at a lower frequency (configurable, default = 1 minute). So to ensure those are dispatched at the correct interval, this PR adjusts the clock so we move it forward more frequently, with smaller values. Note that the issue will still appear once you get to an even more extreme value, but I think in practical terms we cannot support such cases - and perhaps we should limit the top speed.

I've also replaced the promise queue implementation with one that doesn't require specifying an interval (which should mean no artifical delays in dispatching calls)