### PR TITLE
Reduce chances of clock skew

### DIFF
--- a/src/lib/ChargeStation/clock.ts
+++ b/src/lib/ChargeStation/clock.ts
@@ -1,17 +1,28 @@
 // Class representing clock, used to enable 'time travel' in the simulation
 class Clock {
   protected nowDate: Date;
-  protected clockInterval;
+  protected clockInterval?: ReturnType<typeof setInterval>;
+  protected speed: number = 1;
+  protected tickFrequency?: number; // updates per second
 
-  constructor(protected speed = 1) {
+  constructor() {
     this.nowDate = new Date();
-    this.clockInterval = setInterval(() => {
-      this.nowDate.setTime(this.nowDate.getTime() + 100 * this.speed);
-    }, 100);
+    this.tickWithFrequency(1);
   }
 
   public setSpeed(speed: number) {
     this.speed = speed;
+    // the tick frequency is proportional to speed, with a min of 1 and a max of 10
+    // - speed 1  = 1 update / second
+    // - speed 5  = 1.66 updates / second
+    // - speed 10 = 3.33 updates / second
+    // - speed 15 = 5 updates / second
+    // - speed 20 = 6.66 updates / second
+    // - speed 25 = 8.33 updates / second
+    // - speed 25 = 10 updates / second
+    // - speed 30 = 10 updates / second
+    // etc
+    this.tickWithFrequency(Math.max(1, Math.min(10, speed / 3)));
   }
 
   public getSpeed() {
@@ -44,6 +55,20 @@ class Clock {
 
   public adjustBySpeed(input: number): number {
     return Math.floor(input / this.speed);
+  }
+
+  private tickWithFrequency(tickFrequency: number) {
+    if (tickFrequency === this.tickFrequency) {
+      return; // no change
+    }
+    if (this.clockInterval) {
+      clearInterval(this.clockInterval);
+    }
+    const ms = Math.round(1000 / tickFrequency);
+    this.tickFrequency = tickFrequency;
+    this.clockInterval = setInterval(() => {
+      this.nowDate.setTime(this.nowDate.getTime() + ms * this.speed);
+    }, ms);
   }
 }
 


### PR DESCRIPTION
We recently reduced the interval to 100ms, but this had an unfortunate side-effect in that it seemingly increased the chances of clock skew occurring when speed = 1 (likely because the timing is mildly inprecise, and also browsers throttling invocations for inactive tabs, etc).

I couldn't see a way of competely avoiding this problem from occurring, at least whilst we continue to support the speed up mechanism. So this mitigation just looks to reduce the overall problem. Essentially the frequency of updates to the clock is now proportional to the speed. That means with speed 1, we update the clock once every 1000ms like before. As the speed increases, the clock update frequency increases. We bottom this out at 10 updates / second, because anything lower seems generally undesirable.