### PR TITLE
Support MeterValueSampleInterval of 0

### DIFF
--- a/src/lib/ChargeStation/index.ts
+++ b/src/lib/ChargeStation/index.ts
@@ -491,8 +491,7 @@ export class Session {
     private chargeStation: ChargeStation
   ) {
     this.options = options;
-    this.meterValuesInterval =
-      chargeStation.getMeterValueSampleInterval() || 60;
+    this.meterValuesInterval = chargeStation.getMeterValueSampleInterval();
     this.maxPowerKw = options.maxPowerKw || 22;
     this.carBatteryKwh = options.carBatteryKwh || 64;
     this.carBatteryStateOfCharge = options.carBatteryStateOfCharge || 80;
@@ -577,9 +576,10 @@ export class Session {
     }
 
     if (
-      this.lastMeterValuesTimestamp &&
-      clock.secondsSince(this.lastMeterValuesTimestamp) <
-        this.meterValuesInterval
+      this.meterValuesInterval === 0 ||
+      (this.lastMeterValuesTimestamp &&
+        clock.secondsSince(this.lastMeterValuesTimestamp) <
+          this.meterValuesInterval)
     ) {
       return;
     }


### PR DESCRIPTION
Implemented as per the OCPP 1.6 spec:

> A value of "0" (numeric zero), by convention, is to be interpreted to mean that no sampled data should be transmitted.