### PR TITLE
Remove basic auth configuration

### DIFF
--- a/.env
+++ b/.env
@@ -5,13 +5,6 @@
 SERVER_HOST=0.0.0.0
 SERVER_PORT=2100
 
-
-
-# HTTP Basic Auth
-HTTP_BASIC_AUTH_PATH=
-HTTP_BASIC_AUTH_USER=
-HTTP_BASIC_AUTH_PASS=
-
 # Public Variables below
 
 ENV_NAME=development

--- a/README.md
+++ b/README.md
@@ -86,9 +86,6 @@ All configuration is done using environment variables. The default values in
 
 - `SERVER_HOST` - Host to bind to, defaults to `"0.0.0.0"`
 - `SERVER_PORT` - Port to bind to, defaults to `2300`
-- `HTTP_BASIC_AUTH_PATH` - Basic Auth: Path to protect
-- `HTTP_BASIC_AUTH_USER` - Basic Auth: Username
-- `HTTP_BASIC_AUTH_PASS` - Basic Auth: Password
 - `ENV_NAME` - Node environment `development`
 - `APP_NAME` - Default product name to be used in views
 

--- a/serve/static.js
+++ b/serve/static.js
@@ -19,18 +19,6 @@ const app = new Koa();
 
 app.use(statusMiddleware);
 
-if (config.has('HTTP_BASIC_AUTH_PATH')) {
-  app.use(
-    koaMount(
-      config.get('HTTP_BASIC_AUTH_PATH'),
-      koaBasicAuth({
-        user: config.get('HTTP_BASIC_AUTH_USER'),
-        pass: config.get('HTTP_BASIC_AUTH_PASS'),
-      })
-    )
-  );
-}
-
 app
   .use(koaMount('/assets/', assetsMiddleware('./dist/assets')))
   .use(loggingMiddleware())


### PR DESCRIPTION
Not required for general usage - if there is a need to protect the endpoint, people can front with something.