### PR TITLE
Make OCPP backend configurable

### DIFF
--- a/.env
+++ b/.env
@@ -8,6 +8,6 @@ SERVER_PORT=2100
 # Public Variables below
 
 ENV_NAME=development
-
 APP_NAME=Chargestation.one
 APP_URL=http://localhost:2200
+OCPP_BASE_URL=ws://localhost

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ All configuration is done using environment variables. The default values in
 
 - `SERVER_HOST` - Host to bind to, defaults to `"0.0.0.0"`
 - `SERVER_PORT` - Port to bind to, defaults to `2100`
+- `OCPP_BASE_URL` - Default OCPP backend, defaults to `ws://localhost`
 - `ENV_NAME` - Node environment `development`
 - `APP_NAME` - Default product name to be used in views
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -2,6 +2,7 @@ import { SetVariableDataType } from '../schemas/ocpp/2.0/SetVariablesRequest';
 import { ChangeConfigurationRequest } from '../schemas/ocpp/1.6/ChangeConfiguration';
 import { Map } from '../types/generic';
 import { Settings } from 'lib/ChargeStation';
+import { OCPP_BASE_URL } from 'utils/env';
 
 export enum ChargeStationSetting {
   OCPPBaseUrl = 'ocppBaseUrl',
@@ -82,7 +83,7 @@ export const settingsList: SettingsListSetting<ChargeStationSetting>[] = [
     key: ChargeStationSetting.OCPPBaseUrl,
     name: 'OCPP Base URL',
     description: 'Websocket server to connect with',
-    defaultValue: 'ws://localhost:2600/e-flux',
+    defaultValue: OCPP_BASE_URL || 'ws://localhost',
   },
   {
     key: ChargeStationSetting.InteractiveMessagesReply,

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,3 +1,3 @@
-const { APP_NAME, APP_URL, ENV_NAME } = window.__ENV__ || {};
+const { APP_NAME, APP_URL, ENV_NAME, OCPP_BASE_URL } = window.__ENV__ || {};
 
-export { APP_NAME, APP_URL, ENV_NAME };
+export { APP_NAME, APP_URL, ENV_NAME, OCPP_BASE_URL };


### PR DESCRIPTION
Used `OCPP_BASE_URL` as this alignes with the query param override name (`ocppBaseUrl=...`). Resolves #147