### PR TITLE
feat: report Power.Active.Import in meter values

### DIFF
--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/send-meter-values.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/send-meter-values.ts
@@ -14,7 +14,9 @@ const sendMeterValues: ChargeStationEventHandler = async ({
   const now = clock.now();
   const meterReading = formatEnergyMeterReading(
     session.kwhElapsed,
-    chargepoint.getSetting(ChargeStationSetting.EnergyActiveImportUnit) as string
+    chargepoint.getSetting(
+      ChargeStationSetting.EnergyActiveImportUnit
+    ) as string
   );
   const powerReading = formatPowerMeterReading(
     session.currentPowerKw,

--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/send-meter-values.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/send-meter-values.ts
@@ -1,16 +1,24 @@
 import { ChargeStationEventHandler } from 'lib/ChargeStation/eventHandlers';
 import { MeterValuesRequest } from 'schemas/ocpp/1.6/MeterValues';
 import clock from 'lib/ChargeStation/clock';
-import { ChargeStationSetting, formatMeterReading } from 'lib/settings';
+import {
+  ChargeStationSetting,
+  formatEnergyMeterReading,
+  formatPowerMeterReading,
+} from 'lib/settings';
 
 const sendMeterValues: ChargeStationEventHandler = async ({
   chargepoint,
   session,
 }) => {
   const now = clock.now();
-  const meterReading = formatMeterReading(
+  const meterReading = formatEnergyMeterReading(
     session.kwhElapsed,
-    chargepoint.getSetting(ChargeStationSetting.MeterValueUnit) as string
+    chargepoint.getSetting(ChargeStationSetting.EnergyActiveImportUnit) as string
+  );
+  const powerReading = formatPowerMeterReading(
+    session.currentPowerKw,
+    chargepoint.getSetting(ChargeStationSetting.PowerActiveImportUnit) as string
   );
 
   chargepoint.writeCall<MeterValuesRequest>('MeterValues', {
@@ -26,6 +34,18 @@ const sendMeterValues: ChargeStationEventHandler = async ({
             measurand: 'Energy.Active.Import.Register',
             location: 'Outlet',
             unit: meterReading.unit,
+          },
+        ],
+      },
+      {
+        timestamp: now.toISOString(),
+        sampledValue: [
+          {
+            value: powerReading.value,
+            context: 'Sample.Periodic',
+            measurand: 'Power.Active.Import',
+            location: 'Outlet',
+            unit: powerReading.unit,
           },
         ],
       },

--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/send-stop-transaction.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/send-stop-transaction.ts
@@ -3,7 +3,7 @@ import { ChargeStationEventHandler } from 'lib/ChargeStation/eventHandlers';
 import { StopTransactionRequest } from 'schemas/ocpp/1.6/StopTransaction';
 import { signMeterReadings } from 'lib/ChargeStation/ocmf';
 import ChargeStation, { Session } from 'lib/ChargeStation';
-import { ChargeStationSetting, formatMeterReading } from 'lib/settings';
+import { ChargeStationSetting, formatEnergyMeterReading } from 'lib/settings';
 
 type Ocpp16SampledValue =
   StopTransactionRequest['transactionData'][0]['sampledValue'][0];
@@ -27,10 +27,10 @@ const sendStopTransaction: ChargeStationEventHandler = async ({
   );
 
   const meterUnit = chargepoint.getSetting(
-    ChargeStationSetting.MeterValueUnit
+    ChargeStationSetting.EnergyActiveImportUnit
   ) as string;
-  const startReading = formatMeterReading(0, meterUnit);
-  const endReading = formatMeterReading(session.kwhElapsed, meterUnit);
+  const startReading = formatEnergyMeterReading(0, meterUnit);
+  const endReading = formatEnergyMeterReading(session.kwhElapsed, meterUnit);
 
   chargepoint.writeCall<StopTransactionRequest>(
     'StopTransaction',

--- a/src/lib/ChargeStation/eventHandlers/ocpp-20/send-start-transaction.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-20/send-start-transaction.ts
@@ -32,7 +32,9 @@ const sendStartTransaction: ChargeStationEventHandler = async ({
 
   const meterReading = formatEnergyMeterReading(
     session.kwhElapsed,
-    chargepoint.getSetting(ChargeStationSetting.EnergyActiveImportUnit) as string
+    chargepoint.getSetting(
+      ChargeStationSetting.EnergyActiveImportUnit
+    ) as string
   );
 
   chargepoint.writeCall(

--- a/src/lib/ChargeStation/eventHandlers/ocpp-20/send-start-transaction.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-20/send-start-transaction.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { sleep } from 'utils/csv';
 import { ChargeStationEventHandler } from 'lib/ChargeStation/eventHandlers';
-import { ChargeStationSetting, formatMeterReading } from 'lib/settings';
+import { ChargeStationSetting, formatEnergyMeterReading } from 'lib/settings';
 
 import clock from '../../clock';
 
@@ -30,9 +30,9 @@ const sendStartTransaction: ChargeStationEventHandler = async ({
   session.transactionId = transactionId;
   session.isStartingSession = true;
 
-  const meterReading = formatMeterReading(
+  const meterReading = formatEnergyMeterReading(
     session.kwhElapsed,
-    chargepoint.getSetting(ChargeStationSetting.MeterValueUnit) as string
+    chargepoint.getSetting(ChargeStationSetting.EnergyActiveImportUnit) as string
   );
 
   chargepoint.writeCall(

--- a/src/lib/ChargeStation/eventHandlers/ocpp-20/send-stop-transaction.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-20/send-stop-transaction.ts
@@ -1,7 +1,7 @@
 import { sleep } from '../../../../utils/csv';
 
 import { ChargeStationEventHandler } from 'lib/ChargeStation/eventHandlers';
-import { ChargeStationSetting, formatMeterReading } from 'lib/settings';
+import { ChargeStationSetting, formatEnergyMeterReading } from 'lib/settings';
 
 import clock from '../../clock';
 
@@ -19,10 +19,10 @@ const sendStopTransaction: ChargeStationEventHandler = async ({
   }
 
   const meterUnit = chargepoint.getSetting(
-    ChargeStationSetting.MeterValueUnit
+    ChargeStationSetting.EnergyActiveImportUnit
   ) as string;
-  const beginMeter = formatMeterReading(0, meterUnit);
-  const endMeter = formatMeterReading(session.kwhElapsed, meterUnit);
+  const beginMeter = formatEnergyMeterReading(0, meterUnit);
+  const endMeter = formatEnergyMeterReading(session.kwhElapsed, meterUnit);
 
   chargepoint.writeCall(
     'TransactionEvent',

--- a/src/lib/ChargeStation/eventHandlers/ocpp-20/send-transaction-event-updated.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-20/send-transaction-event-updated.ts
@@ -14,7 +14,9 @@ const sendTransationEventUpdated: ChargeStationEventHandler = ({
   const now = clock.now();
   const meterReading = formatEnergyMeterReading(
     session.kwhElapsed,
-    chargepoint.getSetting(ChargeStationSetting.EnergyActiveImportUnit) as string
+    chargepoint.getSetting(
+      ChargeStationSetting.EnergyActiveImportUnit
+    ) as string
   );
   const powerReading = formatPowerMeterReading(
     session.currentPowerKw,

--- a/src/lib/ChargeStation/eventHandlers/ocpp-20/send-transaction-event-updated.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-20/send-transaction-event-updated.ts
@@ -1,6 +1,10 @@
 import { ChargeStationEventHandler } from 'lib/ChargeStation/eventHandlers';
 import { TransactionEventRequest } from 'schemas/ocpp/2.0/TransactionEventRequest';
-import { ChargeStationSetting, formatMeterReading } from 'lib/settings';
+import {
+  ChargeStationSetting,
+  formatEnergyMeterReading,
+  formatPowerMeterReading,
+} from 'lib/settings';
 import clock from '../../clock';
 
 const sendTransationEventUpdated: ChargeStationEventHandler = ({
@@ -8,9 +12,13 @@ const sendTransationEventUpdated: ChargeStationEventHandler = ({
   session,
 }) => {
   const now = clock.now();
-  const meterReading = formatMeterReading(
+  const meterReading = formatEnergyMeterReading(
     session.kwhElapsed,
-    chargepoint.getSetting(ChargeStationSetting.MeterValueUnit) as string
+    chargepoint.getSetting(ChargeStationSetting.EnergyActiveImportUnit) as string
+  );
+  const powerReading = formatPowerMeterReading(
+    session.currentPowerKw,
+    chargepoint.getSetting(ChargeStationSetting.PowerActiveImportUnit) as string
   );
 
   chargepoint.writeCall<TransactionEventRequest>('TransactionEvent', {
@@ -32,6 +40,18 @@ const sendTransationEventUpdated: ChargeStationEventHandler = ({
             measurand: 'Energy.Active.Import.Register',
             location: 'Outlet',
             unitOfMeasure: { unit: meterReading.unit },
+          },
+        ],
+      },
+      {
+        timestamp: now.toISOString(),
+        sampledValue: [
+          {
+            value: Number(powerReading.value),
+            context: 'Sample.Periodic',
+            measurand: 'Power.Active.Import',
+            location: 'Outlet',
+            unitOfMeasure: { unit: powerReading.unit },
           },
         ],
       },

--- a/src/lib/ChargeStation/index.ts
+++ b/src/lib/ChargeStation/index.ts
@@ -43,7 +43,8 @@ export interface Settings {
   g2MobilityIdTagPrefix: string;
   madicLafonSkipPreAuthorize: boolean;
   abbIdTagPrefix: string;
-  meterValueUnit: string;
+  energyActiveImportUnit: string;
+  powerActiveImportUnit: string;
 }
 
 interface CallLogItem {
@@ -521,6 +522,10 @@ export class Session {
 
   get stateOfCharge(): number {
     return this.carBatteryStateOfCharge;
+  }
+
+  get currentPowerKw(): number {
+    return this.suspended ? 0 : this.maxPowerKw;
   }
 
   now(): Date {

--- a/src/lib/ChargeStation/utils.ts
+++ b/src/lib/ChargeStation/utils.ts
@@ -22,7 +22,7 @@ interface SummarizeCommandParams {
 const measurandLabels: Record<string, string> = {
   'Energy.Active.Import.Register': 'energy',
   'Power.Active.Import': 'power',
-  'SoC': 'soc',
+  SoC: 'soc',
 };
 
 function summarizeMeterValues(
@@ -37,9 +37,7 @@ function summarizeMeterValues(
       const rawUnit = sampled.unit ?? sampled.unitOfMeasure?.unit ?? '';
       const unit = rawUnit === 'Percent' ? '%' : rawUnit;
       const value =
-        label === 'soc'
-          ? Number(sampled.value).toFixed(1)
-          : sampled.value;
+        label === 'soc' ? Number(sampled.value).toFixed(1) : sampled.value;
       result[label] = `${value}${unit}`;
     }
   }

--- a/src/lib/ChargeStation/utils.ts
+++ b/src/lib/ChargeStation/utils.ts
@@ -22,6 +22,7 @@ interface SummarizeCommandParams {
 const measurandLabels: Record<string, string> = {
   'Energy.Active.Import.Register': 'energy',
   'Power.Active.Import': 'power',
+  'SoC': 'soc',
 };
 
 function summarizeMeterValues(
@@ -33,8 +34,13 @@ function summarizeMeterValues(
     if (!sampled) continue;
     const label = measurandLabels[sampled.measurand ?? ''];
     if (label) {
-      const unit = sampled.unit ?? sampled.unitOfMeasure?.unit ?? '';
-      result[label] = `${sampled.value}${unit}`;
+      const rawUnit = sampled.unit ?? sampled.unitOfMeasure?.unit ?? '';
+      const unit = rawUnit === 'Percent' ? '%' : rawUnit;
+      const value =
+        label === 'soc'
+          ? Number(sampled.value).toFixed(1)
+          : sampled.value;
+      result[label] = `${value}${unit}`;
     }
   }
   return Object.keys(result).length > 0 ? result : null;

--- a/src/lib/ChargeStation/utils.ts
+++ b/src/lib/ChargeStation/utils.ts
@@ -34,7 +34,7 @@ function summarizeMeterValues(
     const label = measurandLabels[sampled.measurand ?? ''];
     if (label) {
       const unit = sampled.unit ?? sampled.unitOfMeasure?.unit ?? '';
-      result[label] = `${sampled.value}${unit ? unit : ''}`;
+      result[label] = `${sampled.value}${unit}`;
     }
   }
   return Object.keys(result).length > 0 ? result : null;

--- a/src/lib/ChargeStation/utils.ts
+++ b/src/lib/ChargeStation/utils.ts
@@ -5,10 +5,13 @@ interface SummarizeCommandParams {
     meterStart?: number;
     meterStop?: number;
     idTag?: string;
+    idToken?: { idToken?: string };
     status?: string;
+    connectorStatus?: string;
     meterValue?: {
       sampledValue: {
         value: number;
+        measurand?: string;
         unit?: string;
         unitOfMeasure?: { unit?: string };
       }[];
@@ -16,36 +19,52 @@ interface SummarizeCommandParams {
   };
 }
 
+const measurandLabels: Record<string, string> = {
+  'Energy.Active.Import.Register': 'energy',
+  'Power.Active.Import': 'power',
+};
+
+function summarizeMeterValues(
+  meterValue: SummarizeCommandParams['params']['meterValue']
+) {
+  const result: Record<string, string> = {};
+  for (const mv of meterValue ?? []) {
+    const sampled = mv.sampledValue[0];
+    if (!sampled) continue;
+    const label = measurandLabels[sampled.measurand ?? ''];
+    if (label) {
+      const unit = sampled.unit ?? sampled.unitOfMeasure?.unit ?? '';
+      result[label] = `${sampled.value}${unit ? unit : ''}`;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : null;
+}
+
 export function summarizeCommandParams({
   method,
-  params: { idTag, meterStart, meterStop, meterValue, status },
+  params: {
+    idTag,
+    idToken,
+    meterStart,
+    meterStop,
+    meterValue,
+    status,
+    connectorStatus,
+  },
 }: SummarizeCommandParams) {
+  const uid = idTag ?? idToken?.idToken;
   switch (method) {
     case 'StartTransaction':
-      return { meterStart, uid: idTag };
+      return { meterStart, uid };
     case 'StopTransaction':
-      return { meterStop, uid: idTag };
+      return { meterStop, uid };
     case 'Authorize':
-      return { uid: idTag };
+      return { uid };
     case 'StatusNotification':
-      return { status };
-    case 'MeterValues': {
-      const sampled = meterValue?.[0]?.sampledValue[0];
-      const unit = sampled?.unit ?? 'Wh';
-      return {
-        [unit]: sampled?.value,
-      };
-    }
-    case 'TransactionEvent': {
-      const energyMeter = meterValue
-        ?.filter((mv) => mv.sampledValue[0]?.unitOfMeasure?.unit !== 'Percent')
-        .pop();
-      const sampled = energyMeter?.sampledValue[0];
-      const unit = sampled?.unitOfMeasure?.unit ?? 'Wh';
-      return {
-        [unit]: sampled?.value,
-      };
-    }
+      return { status: status ?? connectorStatus };
+    case 'MeterValues':
+    case 'TransactionEvent':
+      return summarizeMeterValues(meterValue);
   }
 
   return null;

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -25,7 +25,8 @@ export enum ChargeStationSetting {
   G2MobilityIdTagPrefix = 'g2MobilityIdTagPrefix',
   MadicLafonSkipPreAuthorize = 'madicLafonSkipPreAuthorize',
   AbbIdTagPrefix = 'abbIdTagPrefix',
-  MeterValueUnit = 'meterValueUnit',
+  EnergyActiveImportUnit = 'energyActiveImportUnit',
+  PowerActiveImportUnit = 'powerActiveImportUnit',
 }
 
 enum SessionSetting {
@@ -60,18 +61,25 @@ export const OCPPVersion = {
 } as const;
 export type OCPPVersion = (typeof OCPPVersion)[keyof typeof OCPPVersion];
 
-export const MeterValueUnit = {
+export const EnergyActiveImportUnit = {
   kWh: 'kWh',
   Wh: 'Wh',
 } as const;
-export type MeterValueUnit =
-  (typeof MeterValueUnit)[keyof typeof MeterValueUnit];
+export type EnergyActiveImportUnit =
+  (typeof EnergyActiveImportUnit)[keyof typeof EnergyActiveImportUnit];
 
-export function formatMeterReading(
+export const PowerActiveImportUnit = {
+  kW: 'kW',
+  W: 'W',
+} as const;
+export type PowerActiveImportUnit =
+  (typeof PowerActiveImportUnit)[keyof typeof PowerActiveImportUnit];
+
+export function formatEnergyMeterReading(
   kwhValue: number,
-  unit: MeterValueUnit | string
-): { value: string; unit: MeterValueUnit } {
-  if (unit === MeterValueUnit.Wh) {
+  unit: EnergyActiveImportUnit | string
+): { value: string; unit: EnergyActiveImportUnit } {
+  if (unit === EnergyActiveImportUnit.Wh) {
     return {
       value: Math.round(kwhValue * 1000).toString(),
       unit: 'Wh',
@@ -80,6 +88,22 @@ export function formatMeterReading(
   return {
     value: kwhValue.toFixed(3),
     unit: 'kWh',
+  };
+}
+
+export function formatPowerMeterReading(
+  kwValue: number,
+  unit: PowerActiveImportUnit | string
+): { value: string; unit: PowerActiveImportUnit } {
+  if (unit === PowerActiveImportUnit.W) {
+    return {
+      value: Math.round(kwValue * 1000).toString(),
+      unit: 'W',
+    };
+  }
+  return {
+    value: kwValue.toFixed(3),
+    unit: 'kW',
   };
 }
 
@@ -178,13 +202,22 @@ export const settingsList: SettingsListSetting<ChargeStationSetting>[] = [
     type: 'string',
   },
   {
-    key: ChargeStationSetting.MeterValueUnit,
+    key: ChargeStationSetting.EnergyActiveImportUnit,
     input: 'dropdown',
-    options: [MeterValueUnit.kWh, MeterValueUnit.Wh],
-    name: 'Meter Value Unit',
+    options: [EnergyActiveImportUnit.kWh, EnergyActiveImportUnit.Wh],
+    name: 'Energy Meter Value Unit',
     description:
-      'Unit for energy meter readings in OCPP 1.6 MeterValues and OCPP 2.x TransactionEvent messages. Does not affect OCPP 1.6 StartTransaction and StopTransaction readings, which are always in Wh.',
-    defaultValue: MeterValueUnit.kWh,
+      'Unit for Energy.Active.Import.Register meter readings in OCPP 1.6 MeterValues and OCPP 2.x TransactionEvent messages. Does not affect OCPP 1.6 StartTransaction and StopTransaction readings, which are always in Wh.',
+    defaultValue: EnergyActiveImportUnit.kWh,
+  },
+  {
+    key: ChargeStationSetting.PowerActiveImportUnit,
+    input: 'dropdown',
+    options: [PowerActiveImportUnit.kW, PowerActiveImportUnit.W],
+    name: 'Power Meter Value Unit',
+    description:
+      'Unit for Power.Active.Import meter readings in OCPP 1.6 MeterValues and OCPP 2.x TransactionEvent messages.',
+    defaultValue: PowerActiveImportUnit.kW,
   },
   {
     key: ChargeStationSetting.ETotemTerminalMode,


### PR DESCRIPTION
## Summary

- Add **Power.Active.Import** measurand to periodic `MeterValues` (OCPP 1.6) and `TransactionEvent(Updated)` (OCPP 2.x) messages, reporting instantaneous charging power alongside the existing energy and SoC readings
- Add a **Power Meter Value Unit** setting (kW default / W) exposed on the settings form, following the same pattern as the energy unit setting
- Rename `MeterValueUnit` to `EnergyActiveImportUnit` for clarity on what each setting and formatter controls
- Fix message log preview to show both readings with measurand labels — e.g. `> MeterValues (energy=0.375kWh power=22.000kW)` instead of `> MeterValues (Wh=375)`
- Fix Authorize and StatusNotification previews to resolve values correctly for both OCPP 1.6 (`idTag`, `status`) and OCPP 2.x (`idToken.idToken`, `connectorStatus`)