### PR TITLE
Fix websocket reconnect handling

### DIFF
--- a/src/lib/ChargeStation/connection.ts
+++ b/src/lib/ChargeStation/connection.ts
@@ -16,17 +16,21 @@ type CallResult = [MessageType, string, unknown];
 type CallError = [MessageType, string, string, string, unknown];
 
 class Connection {
-  private ocppBaseUrl: string;
-  private ocppIdentity: string;
-  private version: string;
+  private readonly ocppBaseUrl: string;
+  private readonly ocppIdentity: string;
+  private readonly version: string;
+  private readonly reconnectDelayMs: number;
   private ready: boolean;
   private messageId: number;
-  private callQueue: PromiseQueue;
+  private readonly callQueue: PromiseQueue;
   private inflight: Inflight | undefined; // the call queue should guarantee only 1 inflight call at any point in time
   private inflightTimeoutMs: number = 10000; // time before we consider the inflight call lost
-  onConnected: null | (() => unknown);
+  private intentionalClose: boolean = false;
+  onConnected: null | (() => void);
+  onDisconnected: null | (() => void);
+  onConnectionFailed: null | (() => void);
+  onReconnecting: null | (() => void);
   private ws: WebSocket;
-  connect = () => {};
 
   onReceiveCall = (method: string, payload: unknown, messageId: string) => {};
   onReceiveCallResult = (messageId: string, payload: string) => {};
@@ -37,25 +41,29 @@ class Connection {
     errorDetails: string
   ) => {};
 
-  constructor(ocppBaseUrl: string, ocppIdentity: string, version: string) {
+  constructor(
+    ocppBaseUrl: string,
+    ocppIdentity: string,
+    version: string,
+    reconnectDelayMs: number = 3000
+  ) {
     this.ocppBaseUrl = ocppBaseUrl;
     this.ocppIdentity = ocppIdentity;
     this.version = version;
+    this.reconnectDelayMs = reconnectDelayMs;
     this.ready = false;
     this.messageId = 1;
     this.callQueue = new PromiseQueue();
     this.onConnected = null;
+    this.onDisconnected = null;
+    this.onConnectionFailed = null;
+    this.onReconnecting = null;
 
-    const url = this.ocppBaseUrl + '/' + this.ocppIdentity;
-    this.ws = new WebSocket(url, this.version);
-
-    this.ws.addEventListener('open', this.onOpen.bind(this));
-    this.ws.addEventListener('message', this.onMessage.bind(this));
-    this.ws.addEventListener('close', this.onClose.bind(this));
-    this.ws.addEventListener('error', this.onError.bind(this));
+    this.ws = this.openWebSocket();
   }
 
   disconnect() {
+    this.intentionalClose = true;
     this.ws.close();
   }
 
@@ -85,7 +93,22 @@ class Connection {
   }
 
   onClose() {
+    const wasConnected = this.ready;
+    this.ready = false;
+    if (wasConnected) {
+      // Connection was established, so this is a normal disconnect.
+      this.onDisconnected && this.onDisconnected();
+    } else {
+      // Connection was never established, so this is a failure to connect.
+      this.onConnectionFailed && this.onConnectionFailed();
+    }
     console.error(`WebSocket closed (no connection)`);
+    if (!this.intentionalClose) {
+      setTimeout(() => {
+        this.onReconnecting && this.onReconnecting();
+        this.ws = this.openWebSocket();
+      }, this.reconnectDelayMs);
+    }
   }
 
   onError(event: Event) {
@@ -131,6 +154,16 @@ class Connection {
       details,
     ];
     this.ws.send(JSON.stringify(formattedMessage));
+  }
+
+  private openWebSocket(): WebSocket {
+    const url = this.ocppBaseUrl + '/' + this.ocppIdentity;
+    const ws = new WebSocket(url, this.version);
+    ws.addEventListener('open', this.onOpen.bind(this));
+    ws.addEventListener('message', this.onMessage.bind(this));
+    ws.addEventListener('close', this.onClose.bind(this));
+    ws.addEventListener('error', this.onError.bind(this));
+    return ws;
   }
 
   private enqueueCall(call: Call) {

--- a/src/lib/ChargeStation/index.ts
+++ b/src/lib/ChargeStation/index.ts
@@ -45,6 +45,7 @@ export interface Settings {
   abbIdTagPrefix: string;
   energyActiveImportUnit: string;
   powerActiveImportUnit: string;
+  reconnectDelaySeconds: number;
 }
 
 interface CallLogItem {
@@ -72,7 +73,6 @@ export default class ChargeStation {
   private ocppVersion: OCPPVersion;
   private callLog: Map<CallLogItem>;
   private emitter: ChargeStationEventEmitter;
-  private numConnectionAttempts: number;
   private connection?: Connection;
   private onLog = ({}) => {};
   private onError = (error: Error) => {};
@@ -96,7 +96,6 @@ export default class ChargeStation {
     this.firmwareVersion = 'v1-000';
     this.ocppVersion = this.settings.ocppConfiguration as OCPPVersion;
     this.emitter = createEventEmitter(this, this.ocppVersion);
-    this.numConnectionAttempts = 0;
     this.currentStatus = {
       1: 'Available',
       2: 'Available',
@@ -130,15 +129,36 @@ export default class ChargeStation {
   }
 
   getConnection(ocppBaseUrl: string, ocppIdentity: string): Connection {
+    const reconnectDelayMs = this.settings.reconnectDelaySeconds * 1000;
     switch (this.ocppVersion) {
       case OCPPVersion.ocpp16:
-        return new Connection(ocppBaseUrl, ocppIdentity, OCPPVersion.ocpp16);
+        return new Connection(
+          ocppBaseUrl,
+          ocppIdentity,
+          OCPPVersion.ocpp16,
+          reconnectDelayMs
+        );
       case OCPPVersion.ocpp201:
-        return new Connection(ocppBaseUrl, ocppIdentity, OCPPVersion.ocpp201);
+        return new Connection(
+          ocppBaseUrl,
+          ocppIdentity,
+          OCPPVersion.ocpp201,
+          reconnectDelayMs
+        );
       case OCPPVersion.ocpp21:
-        return new Connection(ocppBaseUrl, ocppIdentity, OCPPVersion.ocpp21);
+        return new Connection(
+          ocppBaseUrl,
+          ocppIdentity,
+          OCPPVersion.ocpp21,
+          reconnectDelayMs
+        );
       default:
-        return new Connection(ocppBaseUrl, ocppIdentity, OCPPVersion.ocpp16);
+        return new Connection(
+          ocppBaseUrl,
+          ocppIdentity,
+          OCPPVersion.ocpp16,
+          reconnectDelayMs
+        );
     }
   }
 
@@ -155,18 +175,19 @@ export default class ChargeStation {
       this.log('connected', '< Connected!');
       this.emitter.emitEvent(EventTypes.StationConnected);
     };
-    this.connection.onError = (error: Event) => {
-      if (!this.connected) {
-        return;
-      }
-
+    this.connection.onDisconnected = () => {
       this.connected = false;
-
-      // Not sure why this works but TS is complaining
+      this.log('message', '< Disconnected');
+    };
+    this.connection.onConnectionFailed = () => {
+      this.log('message', '< Connection failed');
+    };
+    this.connection.onReconnecting = () => {
+      this.log('message', `> Reconnecting to ${ocppBaseUrl}/${ocppIdentity}`);
+    };
+    this.connection.onError = (error: Event) => {
       // @ts-ignore
       this.log('error', error.message);
-      this.disconnect();
-      this.reconnect();
     };
     this.connection.onReceiveCall = (
       method: string,
@@ -218,8 +239,6 @@ export default class ChargeStation {
         responseReceivedAt: clock.now(),
       });
     };
-    this.connection.connect();
-    this.numConnectionAttempts++;
   }
 
   disconnect() {
@@ -234,22 +253,6 @@ export default class ChargeStation {
     setTimeout(() => {
       this.connect();
     }, 1000);
-  }
-
-  reconnect() {
-    if (this.numConnectionAttempts > 100) {
-      this.log('error', 'Too many connection attempts, giving up');
-      return;
-    }
-    const numSeconds = this.numConnectionAttempts < 5 ? 5 : 30;
-    this.log('message', `> Reconnecting in ${numSeconds} seconds`);
-    setTimeout(() => {
-      if (!this.connection) {
-        throw new Error('Connection is undefined');
-      }
-      this.connection.connect();
-      this.numConnectionAttempts++;
-    }, numSeconds * 1000);
   }
 
   async startSession(

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -27,6 +27,7 @@ export enum ChargeStationSetting {
   AbbIdTagPrefix = 'abbIdTagPrefix',
   EnergyActiveImportUnit = 'energyActiveImportUnit',
   PowerActiveImportUnit = 'powerActiveImportUnit',
+  ReconnectDelaySeconds = 'reconnectDelaySeconds',
 }
 
 enum SessionSetting {
@@ -303,6 +304,14 @@ export const settingsList: SettingsListSetting<ChargeStationSetting>[] = [
       'The prefix to be used for idTags sent relating to payment terminal transactions',
     defaultValue: '',
     predicate: isAbb,
+  },
+  {
+    key: ChargeStationSetting.ReconnectDelaySeconds,
+    name: 'Reconnect Delay',
+    description:
+      'Number of seconds to wait before attempting to reconnect after the WebSocket connection drops',
+    defaultValue: 3,
+    type: 'number',
   },
 ];
 


### PR DESCRIPTION
There was code to try to handle this already, but this was mostly broken. We could be more elaborate with the backoff handling, but I'm honestly not sure it's worth it. And for transparency: changes mostly baked by Claude

<img width="683" height="756" alt="Screenshot 2026-06-05 at 14 08 44" src="https://github.com/user-attachments/assets/f73e3f65-5440-4f82-904f-275a4045e910" />
